### PR TITLE
fix: migrate API domains to 1-level hyphenated subdomains (#142)

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -157,7 +157,7 @@ All caches live on GitHub's blob storage, survive ephemeral runners, and evict a
 | Trigger | Push to `staging` | Manual (`workflow_dispatch`) |
 | ECS tasks | 1 (256 CPU, 512 MB) | 2 (512 CPU, 1024 MB) |
 | VPC CIDR | 10.1.0.0/16 | 10.0.0.0/16 |
-| API domain | `api.staging.parcel-management.qawitherev.com` | `api.parcel-management.qawitherev.com` |
+| API domain | `api-staging-parcel-management.qawitherev.com` | `api-parcel-management.qawitherev.com` |
 | Frontend domain | `staging.parcel-management.qawitherev.com` | `parcel-management.qawitherev.com` |
 | GitHub env | `staging` | `production` |
 

--- a/.github/workflows/cd-backend.yml
+++ b/.github/workflows/cd-backend.yml
@@ -144,9 +144,9 @@ jobs:
         id: domain
         run: |
           if [ "${{ inputs.environment }}" = "production" ]; then
-            echo "api_domain=api.parcel-management.qawitherev.com" >> $GITHUB_OUTPUT
+            echo "api_domain=api-parcel-management.qawitherev.com" >> $GITHUB_OUTPUT
           else
-            echo "api_domain=api.${{ inputs.environment }}.parcel-management.qawitherev.com" >> $GITHUB_OUTPUT
+            echo "api_domain=api-${{ inputs.environment }}-parcel-management.qawitherev.com" >> $GITHUB_OUTPUT
           fi
 
       - name: Health check

--- a/agentic-claude-infra/non-cloud-infra.md
+++ b/agentic-claude-infra/non-cloud-infra.md
@@ -1,0 +1,1308 @@
+# Non-Cloud Infrastructure: Migrating from AWS ECS to a Home Server
+
+## Current State Summary
+
+| Component | AWS Service | Monthly Cost (approx) |
+|---|---|---|
+| Backend (.NET 9 API) | ECS Fargate (512 CPU / 1024 MB) | ~$14.60 |
+| Load Balancer | ALB | ~$20.00 |
+| NAT Gateway | NAT GW + Elastic IP | ~$34.00 |
+| Frontend (Angular SPA) | S3 + CloudFront | ~$1.00 |
+| Container Registry | ECR | ~$0.20 |
+| Secrets | SSM Parameter Store | Free tier |
+| **Total per environment** | | **~$69.80** |
+| **Total (staging + production)** | | **~$139.60** |
+
+External services that stay as-is: MySQL (Aiven), Redis (Redis Cloud), Cloudflare DNS.
+
+---
+
+## Approach 1: Docker Compose on Windows (WSL2 Backend)
+
+### Overview
+
+Run the existing Docker containers on the laptop using Docker Desktop with WSL2.
+This is the closest match to the current ECS setup — the same Docker image that ECS
+runs will run on the laptop. Add an nginx container as reverse proxy and Cloudflare
+Tunnel for secure ingress.
+
+### Architecture
+
+```
+                              Internet
+                                 │
+                                 ▼
+                    ┌─────────────────────────┐
+                    │      Cloudflare         │
+                    │                          │
+                    │  tunnel.qawitherev.com   │
+                    │  (proxies to cloudflared)│
+                    │                          │
+                    │  TLS terminated here     │
+                    │  DDoS protection         │
+                    └────────────┬────────────┘
+                                 │
+                    Cloudflare Tunnel (outbound only)
+                                 │
+                                 ▼
+┌────────────────────────────────────────────────────────────┐
+│                     Home Network                           │
+│  ┌──────────────────────────────────────────────────────┐ │
+│  │              Old Windows Laptop                     │ │
+│  │                                                      │ │
+│  │  ┌────────────────────────────────────────────────┐ │ │
+│  │  │            WSL2 VM (Ubuntu 24.04)              │ │ │
+│  │  │                                                │ │ │
+│  │  │  ┌──────────┐    ┌──────────────────────────┐ │ │ │
+│  │  │  │cloudflared│    │     Docker Compose       │ │ │ │
+│  │  │  │ (tunnel) │───▶│                          │ │ │ │
+│  │  │  └──────────┘    │  ┌────────────────────┐  │ │ │ │
+│  │  │                  │  │   nginx:latest     │  │ │ │ │
+│  │  │                  │  │   (reverse proxy)  │  │ │ │ │
+│  │  │                  │  │                    │  │ │ │ │
+│  │  │                  │  │  /api/* ──────────▶│──│─│─│──▶ backend:5163
+│  │  │                  │  │  /* ──────────────▶│  │ │ │ │   (.NET 9.0 container)
+│  │  │                  │  │       static files │  │ │ │ │
+│  │  │                  │  └────────────────────┘  │ │ │ │
+│  │  │                  │                          │ │ │ │
+│  │  │                  │  ┌────────────────────┐  │ │ │ │
+│  │  │                  │  │  backend:latest    │  │ │ │ │
+│  │  │                  │  │  (ghcr.io/...      │  │ │ │ │
+│  │  │                  │  │   .NET 9.0 API)    │  │ │ │ │
+│  │  │                  │  │  port 5163         │  │ │ │ │
+│  │  │                  │  │                    │  │ │ │ │
+│  │  │                  │  │  Env vars from     │  │ │ │ │
+│  │  │                  │  │  local .env file   │  │ │ │ │
+│  │  │                  │  └────────────────────┘  │ │ │ │
+│  │  │                  └──────────────────────────┘ │ │ │
+│  │  └────────────────────────────────────────────────┘ │ │
+│  │                                                      │ │
+│  │  ┌────────────────────────────────────────────────┐ │ │
+│  │  │  Windows Host                                  │ │ │
+│  │  │  ┌──────────────────┐  ┌────────────────────┐  │ │ │
+│  │  │  │ GitHub Actions   │  │ DDNS Updater       │  │ │ │
+│  │  │  │ Self-Hosted      │  │ (Cloudflare API)   │  │ │ │
+│  │  │  │ Runner           │  │ updates DNS on     │  │ │ │
+│  │  │  │                  │  │ IP change          │  │ │ │
+│  │  │  └──────────────────┘  └────────────────────┘  │ │ │
+│  │  └────────────────────────────────────────────────┘ │ │
+│  └──────────────────────────────────────────────────────┘ │
+└────────────────────────────────────────────────────────────┘
+
+External (unchanged):
+  ┌──────────────┐    ┌──────────────┐
+  │ MySQL (Aiven)│    │ Redis Cloud  │
+  └──────────────┘    └──────────────┘
+```
+
+### Step-by-Step Implementation
+
+#### Step 1: Prepare the Laptop
+
+```powershell
+# Install WSL2 (if not already)
+wsl --install -d Ubuntu-24.04
+
+# Limit WSL2 memory usage (important for old hardware)
+# Create %USERPROFILE%\.wslconfig:
+notepad $env:USERPROFILE\.wslconfig
+```
+
+```ini
+# .wslconfig
+[wsl2]
+memory=2GB
+processors=2
+swap=2GB
+```
+
+```powershell
+# Restart WSL
+wsl --shutdown
+```
+
+#### Step 2: Install Docker in WSL2
+
+```bash
+# Inside WSL2 Ubuntu
+sudo apt update && sudo apt install -y ca-certificates curl
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] \
+  https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+sudo apt update && sudo apt install -y docker-ce docker-ce-cli containerd.io \
+  docker-buildx-plugin docker-compose-plugin
+
+sudo usermod -aG docker $USER
+# Restart WSL2: wsl --shutdown from PowerShell, then reopen
+```
+
+#### Step 3: Create the Docker Compose File
+
+```bash
+mkdir -p ~/parcel-management && cd ~/parcel-management
+```
+
+`~/parcel-management/docker-compose.yml`:
+
+```yaml
+services:
+  nginx:
+    image: nginx:alpine
+    container_name: pm-nginx
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:8080:80"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./frontend/dist:/usr/share/nginx/html:ro
+    depends_on:
+      - backend
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:80/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  backend:
+    image: ghcr.io/qawitherev/parcel-management-backend:latest
+    container_name: pm-backend
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:5163:5163"
+    env_file:
+      - .env
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5163/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
+
+  watchtower:
+    image: containrrr/watchtower
+    container_name: pm-watchtower
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ~/.docker/config.json:/config.json:ro
+    command: --interval 300 pm-backend pm-nginx
+    # Auto-updates containers when new images are pushed
+```
+
+`~/parcel-management/nginx/nginx.conf`:
+
+```nginx
+events {
+    worker_connections 1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    # Rate limiting
+    limit_req_zone $binary_remote_addr zone=api:10m rate=30r/s;
+
+    # Backend upstream
+    upstream backend {
+        server backend:5163;
+    }
+
+    server {
+        listen 80;
+        server_name _;
+
+        # Frontend static files (Angular SPA)
+        root /usr/share/nginx/html;
+        index index.html;
+
+        # API proxy
+        location /api/ {
+            limit_req zone=api burst=20 nodelay;
+            proxy_pass http://backend;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection keep-alive;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $http_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $http_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_read_timeout 60s;
+        }
+
+        # Health check (passthrough)
+        location /health {
+            proxy_pass http://backend;
+        }
+
+        # SPA fallback: serve index.html for unknown routes
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
+    }
+}
+```
+
+`~/parcel-management/.env` (secrets — NOT committed to git):
+
+```bash
+# These values copied from AWS SSM Parameter Store
+ConnectionStrings__DefaultConnection="Server=mysql-7d076dd-qawitherev-hobby-projects.h.aivencloud.com;Port=22115;Database=parcel-management-system;User=avnadmin;Password=xxx;SslMode=VerifyCA;SslCa=/tmp/ca.pem"
+JWTSettings__SecretKey=xxx
+JWTSettings__Issuer=ParcelManagement
+JWTSettings__Audience=ParcelManagement
+JWTSettings__ExpirationMinutes=60
+Notification__Email__Password=xxx
+Notification__Email__Username=apikey
+Notification__Email__SmtpHost=smtp.sendgrid.net
+Notification__Email__SmtpPort=587
+Notification__Email__FromAddress=noreply@qawitherev.com
+RedisSettings__ConnectionString=redis-11664.c100.us-east-1-4.ec2.cloud.redislabs.com:11664,password=xxx,ssl=False
+Admin__Email=admin@parcelmanagement.com
+Admin__Password=xxx
+AllowedOrigins=https://parcel-management.qawitherev.com
+DbCACert="-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----"
+```
+
+#### Step 4: Set Up Cloudflare Tunnel
+
+```bash
+# Inside WSL2
+curl -L https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb -o cloudflared.deb
+sudo dpkg -i cloudflared.deb
+
+# Authenticate (opens browser on Windows host)
+cloudflared tunnel login
+
+# Create tunnel
+cloudflared tunnel create parcel-management
+# This outputs a tunnel ID (e.g., abc123-...) and creates credentials.json
+
+# Configure tunnel
+sudo mkdir -p /etc/cloudflared
+```
+
+`/etc/cloudflared/config.yml`:
+
+```yaml
+tunnel: <tunnel-id-from-create-step>
+credentials-file: /home/<user>/.cloudflared/<tunnel-id>.json
+
+ingress:
+  # Production
+  - hostname: parcel-management.qawitherev.com
+    service: http://localhost:8080
+  - hostname: api-parcel-management.qawitherev.com
+    service: http://localhost:8080
+
+  # Staging
+  - hostname: staging.parcel-management.qawitherev.com
+    service: http://localhost:8081
+  - hostname: api-staging-parcel-management.qawitherev.com
+    service: http://localhost:8081
+
+  # Fallback
+  - service: http_status:404
+```
+
+```bash
+# Route DNS through Cloudflare (creates CNAME records automatically)
+cloudflared tunnel route dns parcel-management parcel-management.qawitherev.com
+cloudflared tunnel route dns parcel-management api-parcel-management.qawitherev.com
+cloudflared tunnel route dns parcel-management staging.parcel-management.qawitherev.com
+cloudflared tunnel route dns parcel-management api-staging-parcel-management.qawitherev.com
+
+# Install as systemd service
+sudo cloudflared service install
+sudo systemctl enable --now cloudflared
+```
+
+#### Step 5: DDNS for Direct Access (optional backup)
+
+```bash
+# Install a DDNS script that updates Cloudflare DNS when public IP changes
+# This is a backup in case the tunnel goes down
+```
+
+Create `~/ddns-update.sh` (run via cron every 5 minutes):
+
+```bash
+#!/bin/bash
+# Updates a backup A record pointing directly to home IP
+# Requires CF_API_TOKEN and CF_ZONE_ID from Cloudflare
+
+CURRENT_IP=$(curl -s https://api.ipify.org)
+RECORD_IP=$(dig +short home.qawitherev.com)
+
+if [ "$CURRENT_IP" != "$RECORD_IP" ]; then
+    curl -s -X PUT "https://api.cloudflare.com/client/v4/zones/$CF_ZONE_ID/dns_records/$RECORD_ID" \
+        -H "Authorization: Bearer $CF_API_TOKEN" \
+        -H "Content-Type: application/json" \
+        --data "{\"type\":\"A\",\"name\":\"home.qawitherev.com\",\"content\":\"$CURRENT_IP\",\"ttl\":120}"
+fi
+```
+
+#### Step 6: Set Up GitHub Actions Self-Hosted Runner
+
+```powershell
+# On Windows host (runs as a Windows service)
+mkdir C:\actions-runner
+cd C:\actions-runner
+
+# Download runner from GitHub repo Settings > Actions > Runners
+Invoke-WebRequest -Uri https://github.com/actions/runner/releases/download/v2.xxx/actions-runner-win-x64-2.xxx.zip -OutFile runner.zip
+Expand-Archive runner.zip .
+
+# Configure
+.\config.cmd --url https://github.com/qawitherev/parcel-management-system --token <token>
+.\svc.cmd install
+.\svc.cmd start
+```
+
+### CI/CD Changes
+
+The CD workflows (`cd-backend.yml`, `cd-frontend.yml`) change to:
+
+**Backend deployment:**
+```yaml
+# Instead of: ECR login → docker push → terraform apply (ECS update)
+# New flow:
+- name: Build Docker image
+  run: docker build -t ghcr.io/qawitherev/pm-backend:${{ github.sha }} .
+
+- name: Push to GitHub Container Registry
+  run: |
+    echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+    docker push ghcr.io/qawitherev/pm-backend:${{ github.sha }}
+    docker tag ghcr.io/qawitherev/pm-backend:${{ github.sha }} ghcr.io/qawitherev/pm-backend:latest
+    docker push ghcr.io/qawitherev/pm-backend:latest
+
+# Watchtower on the laptop auto-pulls and restarts
+# OR: SSH into laptop and run docker compose pull && docker compose up -d
+
+- name: Deploy to home server
+  run: |
+    ssh home-server "cd ~/parcel-management && \
+      docker compose pull backend && \
+      docker compose up -d backend"
+```
+
+**Frontend deployment:**
+```yaml
+# Instead of: aws s3 sync → cloudfront invalidation
+- name: Build Angular app
+  run: npm run build -- --configuration=production
+
+- name: Deploy to home server
+  run: |
+    rsync -avz --delete dist/frontend/browser/ home-server:~/parcel-management/frontend/dist/
+    ssh home-server "docker compose restart nginx"
+```
+
+### Pros & Cons
+
+**Pros:**
+- Same container image as ECS — zero code changes to the backend
+- Watchtower enables automatic updates (pull-based, no push access needed)
+- Docker Compose is well-documented and easy to manage
+- Cloudflare Tunnel gives TLS, DDoS protection, no open ports
+
+**Cons:**
+- Docker Desktop on old hardware consumes significant RAM (2GB+ for VM)
+- WSL2 + Docker VM = two layers of virtualization overhead
+- Image pulls on old hardware will be slow
+- Not using the Windows host directly — most of the laptop sits idle
+
+---
+
+## Approach 2: WSL2 Native (No Docker)
+
+### Overview
+
+Install the .NET 9.0 runtime directly in WSL2 and run the backend as a systemd service.
+Serve frontend static files from nginx running natively in WSL2. This eliminates
+Docker's overhead entirely while keeping the developer experience Linux-native.
+
+### Architecture
+
+```
+                              Internet
+                                 │
+                                 ▼
+                    ┌─────────────────────────┐
+                    │      Cloudflare         │
+                    │  Tunnel + DNS           │
+                    └────────────┬────────────┘
+                                 │
+                                 ▼
+┌────────────────────────────────────────────────────────────┐
+│                     Home Network                           │
+│  ┌──────────────────────────────────────────────────────┐ │
+│  │              Old Windows Laptop                     │ │
+│  │                                                      │ │
+│  │  ┌────────────────────────────────────────────────┐ │ │
+│  │  │            WSL2 VM (Ubuntu 24.04)              │ │ │
+│  │  │                                                │ │ │
+│  │  │  systemd ─────────────────────────┐            │ │ │
+│  │  │                                   │            │ │ │
+│  │  │  ┌────────────────────────────┐   │            │ │ │
+│  │  │  │     nginx (native)         │   │            │ │ │
+│  │  │  │     /etc/nginx/sites-      │   │            │ │ │
+│  │  │  │     enabled/pm             │   │            │ │ │
+│  │  │  │                            │   │            │ │ │
+│  │  │  │  /*       → /var/www/pm/   │   │            │ │ │
+│  │  │  │  /api/*   → proxy_pass     │───│────────────┼─┐
+│  │  │  │             127.0.0.1:5163 │   │            │ │
+│  │  │  └────────────────────────────┘   │            │ │
+│  │  │                                   │            │ │
+│  │  │  ┌────────────────────────────┐   │            │ │
+│  │  │  │  pm-api.service            │   │            │ │
+│  │  │  │  (systemd unit)            │◄──┘            │ │
+│  │  │  │                            │                │ │
+│  │  │  │  ExecStart=/usr/bin/dotnet │                │ │
+│  │  │  │    /opt/pm/ParcelMgmt.dll  │                │ │
+│  │  │  │  WorkingDirectory=/opt/pm  │                │ │
+│  │  │  │  User=pm-svc              │                │ │
+│  │  │  │  EnvironmentFile=/etc/pm/  │                │ │
+│  │  │  │    .env                    │                │ │
+│  │  │  │  Restart=always           │                │ │
+│  │  │  └────────────────────────────┘                │ │
+│  │  │                                                │ │
+│  │  │  ┌────────────────────────────┐                │ │
+│  │  │  │  cloudflared.service      │                │ │
+│  │  │  │  (Cloudflare Tunnel)      │                │ │
+│  │  │  └────────────────────────────┘                │ │
+│  │  │                                                │ │
+│  │  │  ┌────────────────────────────┐                │ │
+│  │  │  │  pm-deploy.service        │                │ │
+│  │  │  │  (simple HTTP listener    │                │ │
+│  │  │  │   for deployment webhook) │                │ │
+│  │  │  └────────────────────────────┘                │ │
+│  │  └────────────────────────────────────────────────┘ │ │
+│  │                                                      │ │
+│  │  ┌────────────────────────────────────────────────┐ │ │
+│  │  │  Windows Host                                  │ │ │
+│  │  │  ┌──────────────────┐  ┌────────────────────┐  │ │ │
+│  │  │  │ WSL Auto-Start   │  │ DDNS Updater       │  │ │ │
+│  │  │  │ (scheduled task) │  │ (scheduled task)   │  │ │ │
+│  │  │  └──────────────────┘  └────────────────────┘  │ │ │
+│  │  └────────────────────────────────────────────────┘ │ │
+│  └──────────────────────────────────────────────────────┘ │
+└────────────────────────────────────────────────────────────┘
+```
+
+### Step-by-Step Implementation
+
+#### Step 1: Prepare WSL2
+
+```powershell
+# Install WSL2
+wsl --install -d Ubuntu-24.04
+
+# Configure memory limits
+notepad $env:USERPROFILE\.wslconfig
+```
+
+```ini
+[wsl2]
+memory=2GB
+processors=2
+swap=2GB
+
+[boot]
+systemd=true
+```
+
+```powershell
+wsl --shutdown
+```
+
+#### Step 2: Install .NET Runtime in WSL2
+
+```bash
+# Inside WSL2
+wget https://packages.microsoft.com/config/ubuntu/24.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+sudo dpkg -i packages-microsoft-prod.deb
+sudo apt update && sudo apt install -y aspnetcore-runtime-9.0 nginx curl
+
+# Verify
+dotnet --version
+```
+
+#### Step 3: Deploy the Backend
+
+```bash
+# Create directory structure
+sudo mkdir -p /opt/parcel-management/backend
+sudo mkdir -p /opt/parcel-management/frontend
+sudo mkdir -p /etc/parcel-management
+
+# Create service user
+sudo useradd -r -s /bin/false pm-svc
+sudo chown -R pm-svc:pm-svc /opt/parcel-management
+```
+
+`/etc/parcel-management/.env`:
+
+```bash
+# Same environment variables as the .env in Approach 1
+ConnectionStrings__DefaultConnection="Server=mysql-7d076dd-qawitherev-hobby-projects.h.aivencloud.com;..."
+JWTSettings__SecretKey=xxx
+JWTSettings__Issuer=ParcelManagement
+JWTSettings__Audience=ParcelManagement
+JWTSettings__ExpirationMinutes=60
+# ... (all other env vars)
+ASPNETCORE_URLS=http://127.0.0.1:5163
+ASPNETCORE_ENVIRONMENT=Production
+```
+
+`/etc/systemd/system/pm-api.service`:
+
+```ini
+[Unit]
+Description=Parcel Management API
+After=network.target
+
+[Service]
+Type=simple
+User=pm-svc
+Group=pm-svc
+WorkingDirectory=/opt/parcel-management/backend
+EnvironmentFile=/etc/parcel-management/.env
+ExecStart=/usr/bin/dotnet /opt/parcel-management/backend/ParcelManagement.Api.dll
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=pm-api
+
+# Security hardening
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+ReadWritePaths=/opt/parcel-management
+PrivateTmp=yes
+
+[Install]
+WantedBy=multi-user.target
+```
+
+#### Step 4: Configure Nginx
+
+`/etc/nginx/sites-available/parcel-management`:
+
+```nginx
+# Rate limiting
+limit_req_zone $binary_remote_addr zone=api:10m rate=30r/s;
+
+server {
+    listen 8080;
+    server_name _;
+
+    # Gzip compression
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml;
+
+    # Frontend static files
+    root /opt/parcel-management/frontend;
+    index index.html;
+
+    # Security headers
+    add_header X-Frame-Options "DENY" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+    # API proxy
+    location /api/ {
+        limit_req zone=api burst=20 nodelay;
+        proxy_pass http://127.0.0.1:5163;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection keep-alive;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $http_x_forwarded_for;
+        proxy_set_header X-Forwarded-For $http_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 60s;
+    }
+
+    # Health check passthrough
+    location /health {
+        proxy_pass http://127.0.0.1:5163;
+    }
+
+    # SPA fallback
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}
+```
+
+```bash
+sudo ln -s /etc/nginx/sites-available/parcel-management /etc/nginx/sites-enabled/
+sudo rm /etc/nginx/sites-enabled/default
+sudo nginx -t && sudo systemctl reload nginx
+```
+
+#### Step 5: Set Up Cloudflare Tunnel
+
+Same as Approach 1 Step 4 — cloudflared runs as a systemd service inside WSL2, proxying to `http://localhost:8080`.
+
+#### Step 6: Deployment Webhook (Simple HTTP Listener)
+
+Instead of SSH, use a simple webhook receiver that triggers `git pull` + service restart:
+
+```bash
+# Create deployment script
+sudo nano /usr/local/bin/pm-deploy.sh
+```
+
+```bash
+#!/bin/bash
+set -e
+
+# Pull latest from GitHub, build, and restart
+LOG_FILE="/var/log/pm-deploy.log"
+
+echo "[$(date)] Deployment triggered" >> "$LOG_FILE"
+
+# Pull backend source
+cd /opt/parcel-management/repo
+git pull origin main
+
+# Build
+cd backend/src
+dotnet publish ParcelManagement.Api -c Release -o /opt/parcel-management/backend-new
+
+# Atomic swap
+sudo systemctl stop pm-api
+rm -rf /opt/parcel-management/backend
+mv /opt/parcel-management/backend-new /opt/parcel-management/backend
+sudo chown -R pm-svc:pm-svc /opt/parcel-management/backend
+sudo systemctl start pm-api
+
+# Update frontend
+cd /opt/parcel-management/repo/frontend
+npm ci && npm run build -- --configuration=production
+rm -rf /opt/parcel-management/frontend/*
+cp -r dist/frontend/browser/* /opt/parcel-management/frontend/
+
+echo "[$(date)] Deployment complete" >> "$LOG_FILE"
+```
+
+Use a simple Python webhook listener (or use `webhook` package):
+
+```bash
+sudo apt install -y webhook
+```
+
+`/etc/webhook.conf`:
+
+```json
+[
+  {
+    "id": "pm-deploy",
+    "execute-command": "/usr/local/bin/pm-deploy.sh",
+    "command-working-directory": "/opt/parcel-management",
+    "response-message": "Deploy triggered",
+    "trigger-rule": {
+      "match": {
+        "type": "payload-hash-sha256",
+        "secret": "<webhook-secret>",
+        "parameter": {
+          "source": "header",
+          "name": "X-Hub-Signature-256"
+        }
+      }
+    }
+  }
+]
+```
+
+```bash
+webhook -hooks /etc/webhook.conf -port 9000 &
+```
+
+GitHub Actions then calls: `https://home.qawitherev.com:9000/hooks/pm-deploy`
+
+### CI/CD Changes
+
+**Backend:**
+```yaml
+# Instead of ECR push + ECS update:
+- name: Notify home server
+  run: |
+    curl -X POST https://home.qawitherev.com:9000/hooks/pm-deploy \
+      -H "X-Hub-Signature-256: sha256=$(echo -n '${{ toJson(github) }}' | \
+        openssl dgst -sha256 -hmac '${{ secrets.WEBHOOK_SECRET }}')"
+```
+
+**Frontend:**
+Same webhook triggers a full deploy script that rebuilds both backend and frontend.
+
+### Pros & Cons
+
+**Pros:**
+- No Docker overhead — uses 50-70% less RAM than Approach 1
+- .NET runs at native speed (no container layer)
+- Full control via systemd (logging via journald, automatic restarts)
+- Can use `dotnet publish` directly, no Docker image to push
+- Minimum moving parts: nginx + .NET + systemd + cloudflared
+
+**Cons:**
+- Must install .NET SDK on the laptop (for `dotnet publish` during deploy)
+- Build happens on the old laptop — slow on old hardware
+- No container isolation (though systemd unit hardening helps)
+- OS updates may break .NET runtime compatibility
+- Different from ECS prod environment ("it works on my laptop" risk)
+
+---
+
+## Approach 3: Windows Native with IIS
+
+### Overview
+
+Run everything directly on Windows without any Linux VM. The .NET backend runs in IIS
+via the ASP.NET Core Hosting Bundle. Frontend static files are served from IIS as well.
+This uses only the Windows host with zero virtualization overhead.
+
+### Architecture
+
+```
+                              Internet
+                                 │
+                                 ▼
+                    ┌─────────────────────────┐
+                    │      Cloudflare         │
+                    │  Tunnel + DNS           │
+                    └────────────┬────────────┘
+                                 │
+                                 ▼
+┌────────────────────────────────────────────────────────────┐
+│                     Home Network                           │
+│  ┌──────────────────────────────────────────────────────┐ │
+│  │              Old Windows Laptop                     │ │
+│  │                                                      │ │
+│  │  ┌────────────────────────────────────────────────┐ │ │
+│  │  │              IIS (inetmgr)                     │ │ │
+│  │  │                                                │ │ │
+│  │  │  Site: parcel-management (port 8080)           │ │ │
+│  │  │  ┌──────────────────────────────────────────┐ │ │ │
+│  │  │  │  Application Pool: pm-api                │ │ │ │
+│  │  │  │  (No managed code)                       │ │ │ │
+│  │  │  │  Identity: pm-svc (local user)           │ │ │ │
+│  │  │  │                                          │ │ │ │
+│  │  │  │  ┌────────────────────────────────────┐  │ │ │ │
+│  │  │  │  │  ASP.NET Core Module               │  │ │ │ │
+│  │  │  │  │  (aspnetcoremodule.dll)            │  │ │ │ │
+│  │  │  │  │                                    │  │ │ │ │
+│  │  │  │  │  Process: dotnet PariManagement.dll│  │ │ │ │
+│  │  │  │  │  Port: dynamic (IIS-managed)       │  │ │ │ │
+│  │  │  │  └────────────────────────────────────┘  │ │ │ │
+│  │  │  └──────────────────────────────────────────┘ │ │ │
+│  │  │                                                │ │ │
+│  │  │  URL Rewrite Rules:                            │ │ │
+│  │  │  /api/* → reverse proxy to backend process      │ │ │
+│  │  │  /*     → static files from C:\pm\frontend      │ │ │
+│  │  │  (SPA fallback: /* → /index.html)               │ │ │
+│  │  └────────────────────────────────────────────────┘ │ │
+│  │                                                      │ │
+│  │  ┌──────────────────┐  ┌──────────────────────────┐ │ │
+│  │  │ cloudflared.exe  │  │ GitHub Actions Runner    │ │ │
+│  │  │ (Windows service)│  │ (Windows service)        │ │ │
+│  │  │                  │  │                          │ │ │
+│  │  │ Proxies:         │  │ Listens for workflow     │ │ │
+│  │  │ Cloudflare → IIS │  │ jobs, runs deploy.ps1    │ │ │
+│  │  └──────────────────┘  └──────────────────────────┘ │ │
+│  │                                                      │ │
+│  │  ┌────────────────────────────────────────────────┐ │ │
+│  │  │  Scheduled Tasks                               │ │ │
+│  │  │  ├── DDNS Updater (every 5 min)                │ │ │
+│  │  │  ├── IIS Warmup (on boot)                      │ │ │
+│  │  │  └── Log Cleanup (weekly)                      │ │ │
+│  │  └────────────────────────────────────────────────┘ │ │
+│  └──────────────────────────────────────────────────────┘ │
+└────────────────────────────────────────────────────────────┘
+```
+
+### Step-by-Step Implementation
+
+#### Step 1: Enable IIS and Required Features
+
+```powershell
+# Run as Administrator
+Enable-WindowsOptionalFeature -Online -FeatureName IIS-WebServerRole
+Enable-WindowsOptionalFeature -Online -FeatureName IIS-WebServer
+Enable-WindowsOptionalFeature -Online -FeatureName IIS-CommonHttpFeatures
+Enable-WindowsOptionalFeature -Online -FeatureName IIS-HttpErrors
+Enable-WindowsOptionalFeature -Online -FeatureName IIS-StaticContent
+Enable-WindowsOptionalFeature -Online -FeatureName IIS-DefaultDocument
+Enable-WindowsOptionalFeature -Online -FeatureName IIS-ApplicationInit
+Enable-WindowsOptionalFeature -Online -FeatureName IIS-URLRewrite
+
+# Restart
+Restart-Computer
+```
+
+#### Step 2: Install .NET Hosting Bundle
+
+```powershell
+# Download and install ASP.NET Core 9.0 Hosting Bundle
+# https://dotnet.microsoft.com/en-us/download/dotnet/9.0
+# Get the "Hosting Bundle" installer (includes runtime + IIS module)
+Invoke-WebRequest -Uri "https://download.visualstudio.microsoft.com/download/pr/xxx/dotnet-hosting-9.0.0-win.exe" -OutFile dotnet-hosting.exe
+Start-Process dotnet-hosting.exe -ArgumentList '/quiet /norestart' -Wait
+Restart-Computer
+
+# Verify
+dotnet --version
+# Should show 9.0.x
+```
+
+#### Step 3: Deploy the Backend to IIS
+
+```powershell
+# Create directory structure
+New-Item -Path C:\pm\backend -ItemType Directory -Force
+New-Item -Path C:\pm\frontend -ItemType Directory -Force
+New-Item -Path C:\pm\logs -ItemType Directory -Force
+
+# Create local user for the app pool
+$password = ConvertTo-SecureString "GenerateARandomPasswordHere123!" -AsPlainText -Force
+New-LocalUser -Name "pm-svc" -Password $password -PasswordNeverExpires
+```
+
+`C:\pm\backend\web.config`:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <location path="." inheritInChildApplications="false">
+    <system.webServer>
+      <handlers>
+        <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
+      </handlers>
+      <aspNetCore processPath="dotnet" arguments="ParcelManagement.Api.dll"
+                  stdoutLogEnabled="true" stdoutLogFile="C:\pm\logs\stdout.log"
+                  hostingModel="inprocess">
+        <environmentVariables>
+          <environmentVariable name="ASPNETCORE_ENVIRONMENT" value="Production" />
+        </environmentVariables>
+      </aspNetCore>
+    </system.webServer>
+  </location>
+</configuration>
+```
+
+**Create IIS Site via PowerShell:**
+
+```powershell
+Import-Module WebAdministration
+
+# Create app pool
+New-WebAppPool -Name "pm-api"
+Set-ItemProperty -Path "IIS:\AppPools\pm-api" -Name managedRuntimeVersion -Value ""
+Set-ItemProperty -Path "IIS:\AppPools\pm-api" -Name processModel.identityType -Value SpecificUser
+Set-ItemProperty -Path "IIS:\AppPools\pm-api" -Name processModel.userName -Value ".\pm-svc"
+Set-ItemProperty -Path "IIS:\AppPools\pm-api" -Name processModel.password -Value "GenerateARandomPasswordHere123!"
+Set-ItemProperty -Path "IIS:\AppPools\pm-api" -Name startMode -Value "AlwaysRunning"
+Set-ItemProperty -Path "IIS:\AppPools\pm-api" -Name recycling.periodicRestart.time -Value "00:00:00"
+
+# Create site
+New-Website -Name "parcel-management" `
+    -PhysicalPath "C:\pm\frontend" `
+    -ApplicationPool "pm-api" `
+    -Port 8080
+
+# Add backend as application under /api
+New-WebApplication -Name "api" `
+    -Site "parcel-management" `
+    -PhysicalPath "C:\pm\backend" `
+    -ApplicationPool "pm-api"
+
+# Set environment variables at the server level
+Add-WebConfiguration -PSPath "MACHINE/WEBROOT/APPHOST" `
+    -Filter "appSettings" `
+    -Value @{ key="ConnectionStrings__DefaultConnection"; value="Server=..." }
+# ... repeat for all env vars (or use a script to read from .env file)
+```
+
+#### Step 4: Configure URL Rewrite for SPA
+
+`C:\pm\frontend\web.config`:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <system.webServer>
+    <rewrite>
+      <rules>
+        <!-- Don't rewrite API calls or static files -->
+        <rule name="API" stopProcessing="true">
+          <match url="^api/(.*)" />
+          <action type="None" />
+        </rule>
+        <rule name="StaticFiles" stopProcessing="true">
+          <match url=".*\.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot|json|txt|map)$" />
+          <action type="None" />
+        </rule>
+        <!-- SPA fallback: everything else goes to index.html -->
+        <rule name="SPA Fallback">
+          <match url=".*" />
+          <conditions logicalGrouping="MatchAll">
+            <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
+            <add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true" />
+          </conditions>
+          <action type="Rewrite" url="/index.html" />
+        </rule>
+      </rules>
+    </rewrite>
+
+    <!-- Security headers -->
+    <httpProtocol>
+      <customHeaders>
+        <add name="X-Frame-Options" value="DENY" />
+        <add name="X-Content-Type-Options" value="nosniff" />
+        <add name="Referrer-Policy" value="strict-origin-when-cross-origin" />
+      </customHeaders>
+    </httpProtocol>
+
+    <!-- Caching for static assets -->
+    <staticContent>
+      <clientCache cacheControlMode="UseMaxAge" cacheControlMaxAge="30.00:00:00" />
+    </staticContent>
+  </system.webServer>
+</configuration>
+```
+
+#### Step 5: Install Cloudflare Tunnel (Windows)
+
+```powershell
+# Download cloudflared for Windows
+Invoke-WebRequest -Uri "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-windows-amd64.exe" `
+    -OutFile "C:\pm\cloudflared.exe"
+
+# Authenticate (run from CMD, not PowerShell ISE)
+C:\pm\cloudflared.exe tunnel login
+
+# Create tunnel
+C:\pm\cloudflared.exe tunnel create parcel-management
+```
+
+`%USERPROFILE%\.cloudflared\config.yml`:
+
+```yaml
+tunnel: <tunnel-id>
+credentials-file: C:\Users\<user>\.cloudflared\<tunnel-id>.json
+
+ingress:
+  - hostname: parcel-management.qawitherev.com
+    service: http://localhost:8080
+  - hostname: api-parcel-management.qawitherev.com
+    service: http://localhost:8080
+  - hostname: staging.parcel-management.qawitherev.com
+    service: http://localhost:8081
+  - hostname: api-staging-parcel-management.qawitherev.com
+    service: http://localhost:8081
+  - service: http_status:404
+```
+
+```powershell
+# Route DNS
+C:\pm\cloudflared.exe tunnel route dns parcel-management parcel-management.qawitherev.com
+C:\pm\cloudflared.exe tunnel route dns parcel-management api-parcel-management.qawitherev.com
+# ... staging too
+
+# Install as Windows service
+C:\pm\cloudflared.exe service install
+Start-Service cloudflared
+```
+
+#### Step 6: Set Up GitHub Actions Self-Hosted Runner
+
+```powershell
+# Download and configure runner
+mkdir C:\actions-runner
+cd C:\actions-runner
+Invoke-WebRequest -Uri https://github.com/actions/runner/releases/download/v2.xxx/actions-runner-win-x64-2.xxx.zip -OutFile runner.zip
+Expand-Archive runner.zip .
+.\config.cmd --url https://github.com/qawitherev/parcel-management-system --token <token> --name home-laptop
+.\svc.cmd install
+.\svc.cmd start
+```
+
+#### Step 7: Deployment Script
+
+`C:\pm\deploy.ps1` (triggered by GitHub Actions self-hosted runner):
+
+```powershell
+param(
+    [string]$Component = "all"  # "backend", "frontend", or "all"
+)
+
+$ErrorActionPreference = "Stop"
+$LogFile = "C:\pm\logs\deploy-$(Get-Date -Format 'yyyy-MM-dd-HHmmss').log"
+
+Function Write-Log {
+    param($Message)
+    $line = "[$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')] $Message"
+    Add-Content -Path $LogFile -Value $line
+    Write-Host $line
+}
+
+Import-Module WebAdministration
+
+if ($Component -in @("backend", "all")) {
+    Write-Log "Building backend..."
+    Set-Location C:\pm\repo\backend\src
+    dotnet publish ParcelManagement.Api -c Release -o C:\pm\backend-new
+    Write-Log "Backend build complete."
+
+    Write-Log "Stopping app pool..."
+    Stop-WebAppPool -Name "pm-api"
+
+    Write-Log "Swapping backend..."
+    Remove-Item -Recurse -Force C:\pm\backend\*
+    Copy-Item -Recurse C:\pm\backend-new\* C:\pm\backend\
+
+    Write-Log "Starting app pool..."
+    Start-WebAppPool -Name "pm-api"
+    Write-Log "Backend deployed."
+}
+
+if ($Component -in @("frontend", "all")) {
+    Write-Log "Building frontend..."
+    Set-Location C:\pm\repo\frontend
+    npm ci
+    npm run build -- --configuration=production
+    Write-Log "Frontend build complete."
+
+    Write-Log "Swapping frontend..."
+    Remove-Item -Recurse -Force C:\pm\frontend\*
+    Copy-Item -Recurse C:\pm\repo\frontend\dist\frontend\browser\* C:\pm\frontend\
+
+    Write-Log "Frontend deployed."
+}
+
+Write-Log "Deployment complete."
+```
+
+### CI/CD Changes
+
+With a self-hosted runner, the CI/CD workflows remain almost identical. The key change:
+the `runs-on` label changes from `ubuntu-latest` to `self-hosted`:
+
+```yaml
+jobs:
+  deploy-backend:
+    runs-on: [self-hosted, home-laptop]
+    # Runner is on the laptop itself, so:
+    # - No need to push Docker images
+    # - No need for SSH
+    # - Build happens directly on the server
+    steps:
+      - uses: actions/checkout@v4
+      - name: Deploy backend
+        run: |
+          dotnet publish backend/src/ParcelManagement.Api -c Release -o C:\pm\backend-new
+          C:\pm\deploy.ps1 -Component backend
+```
+
+### Pros & Cons
+
+**Pros:**
+- Zero virtualization overhead — all RAM/CPU available to the app
+- IIS is a mature, well-tested web server on Windows
+- ASP.NET Core in-process hosting in IIS is efficient
+- No Linux knowledge needed — everything is Windows-native
+- Self-hosted runner means build + deploy happen on the same machine
+
+**Cons:**
+- IIS configuration is XML-heavy and harder to version-control
+- Windows updates may reboot the machine (can schedule active hours)
+- Running builds on old hardware is slow
+- IIS has a larger baseline memory footprint than nginx
+- Windows license cost (though pre-installed on the laptop)
+- Less community tooling for IaC (no Terraform, harder to automate IIS setup)
+
+---
+
+## Comparison Matrix
+
+| Criteria | Approach 1 (Docker/WSL2) | Approach 2 (WSL2 Native) | Approach 3 (Windows IIS) |
+|---|---|---|---|
+| **RAM usage (idle)** | ~1.5 GB | ~500 MB | ~800 MB |
+| **CPU overhead** | Medium (VM + containers) | Low (VM only) | None |
+| **Closest to ECS** | Yes (same image) | No (bare metal) | No (IIS host) |
+| **Setup complexity** | Medium | Medium | High |
+| **Deployment speed** | Fast (pull image) | Slow (compile on device) | Slow (compile on device) |
+| **Version control** | docker-compose.yml | systemd units + scripts | PowerShell + XML |
+| **Auto-restart on crash** | Docker restart policy | systemd Restart=always | IIS app pool auto-start |
+| **TLS termination** | Cloudflare Tunnel | Cloudflare Tunnel | Cloudflare Tunnel |
+| **Logging** | Docker logs → journald | journald | Event Viewer + log files |
+| **Build location** | GitHub Actions (cloud) | On the laptop | On the laptop |
+| **IaC support** | docker-compose (YAML) | Ansible (optional) | DSC / manual |
+| **Recommendation for old laptop** | ⭐⭐ | ⭐⭐⭐ | ⭐ |
+
+---
+
+## Shared Setup (All Approaches)
+
+These steps are the same regardless of which approach you choose.
+
+### DNS Migration from Route53 to Cloudflare
+
+1. Export zone file from Route53
+2. Import to Cloudflare (or let Cloudflare scan existing records)
+3. Update nameservers at your domain registrar to point to Cloudflare
+4. Recreate the same A/CNAME records in Cloudflare:
+   - `parcel-management.qawitherev.com` → Cloudflare Tunnel
+   - `api-parcel-management.qawitherev.com` → Cloudflare Tunnel
+   - `staging.parcel-management.qawitherev.com` → Cloudflare Tunnel
+   - `api-staging-parcel-management.qawitherev.com` → Cloudflare Tunnel
+
+### TLS Certificates
+
+Cloudflare provides free edge certificates (TLS from user to Cloudflare).
+No ACM certificate management needed anymore.
+Cloudflare Tunnel encrypts the connection from Cloudflare to the laptop.
+
+### Secrets Management
+
+Options for replacing AWS SSM Parameter Store:
+
+1. **.env file on disk** (simplest) — restrict file permissions to the service user only
+2. **Windows Credential Manager** (Approach 3) — store secrets, access via PowerShell
+3. **1Password CLI** — `op inject -i .env.template -o .env`
+4. **GitHub Secrets + envsubst** — inject during deployment
+
+Recommended for simplicity: `.env` file with restricted permissions (`chmod 600` on WSL2, or NTFS ACLs on Windows).
+
+### CI/CD Summary
+
+All approaches converge on one of two deployment patterns:
+
+**Pattern A — Cloud build, local pull (Approach 1 with Docker):**
+```
+Git push → GitHub Actions → Build Docker image → Push to GHCR
+→ Watchtower on laptop detects new image → Pull + restart container
+```
+
+**Pattern B — Self-hosted runner builds on laptop (Approaches 2 & 3):**
+```
+Git push → GitHub Actions → Self-hosted runner on laptop
+→ git pull → dotnet publish / npm build → restart service
+```
+
+Choose Pattern A if build speed matters and you want the laptop to only run pre-built artifacts.
+Choose Pattern B if you want fewer external dependencies (no container registry).
+
+### Staging Environment
+
+For staging, run a second instance on a different port:
+
+**Approach 1:** Second docker-compose file (`docker-compose.staging.yml`) with different ports
+**Approach 2:** Second systemd unit (`pm-api-staging.service`) on port 5164
+**Approach 3:** Second IIS site (`parcel-management-staging`) on port 8081
+
+The nginx/IIS configuration proxies based on the hostname to the correct backend port.
+
+### Monitoring & Health Checks
+
+- **Uptime Kuma** (self-hosted, lightweight) — ping `/health` every 60s, alert on Discord/email
+- **Windows Task Manager** or **htop in WSL2** — watch resource usage
+- **journald / Event Viewer** — check logs on issues
+- Cloudflare Analytics provides traffic and threat metrics
+
+### Backup Strategy
+
+- Database (Aiven): managed backups continue as-is
+- Source code: GitHub (unchanged)
+- Laptop configs (`docker-compose.yml`, systemd units, nginx configs): commit to repo under `agentic-claude-infra/`
+- `.env` secrets: back up to a password manager (1Password, Bitwarden)
+
+### Power & Internet Reliability
+
+- **UPS (uninterruptible power supply):** Highly recommended. Prevents data corruption on power loss
+- **BIOS setting:** Set laptop to power on when AC is connected (so it auto-boots after power returns)
+- **Windows power settings:** Set to never sleep, lid close = do nothing
+- **Internet:** Cloudflare Tunnel auto-reconnects when internet returns. If using DDNS, cron job updates within 5 minutes
+
+---
+
+## Estimated Monthly Savings
+
+| Item | AWS Cost (staging+prod) | Home Server Cost |
+|---|---|---|
+| ECS Fargate (both envs) | ~$14.60 | $0 |
+| ALB (both envs) | ~$40.00 | $0 |
+| NAT Gateways (both envs) | ~$68.00 | $0 |
+| CloudFront/S3 | ~$2.00 | $0 |
+| ECR | ~$0.40 | $0 |
+| Route53 (hosted zones) | ~$1.00 | $0 |
+| Electricity (laptop 24/7, ~30W) | — | ~$2.50/mo |
+| Cloudflare (DNS + Tunnel) | — | Free tier |
+| **Total** | **~$126.00/mo** | **~$2.50/mo** |
+
+**Annual savings: ~$1,482.00**
+
+Note: Database (Aiven MySQL) and Redis (Redis Cloud) costs are excluded since they remain unchanged in both scenarios.
+
+---
+
+## Final Recommendation
+
+**For an old Windows laptop, Approach 2 (WSL2 Native) is the strongest choice:**
+
+1. It bypasses Docker's RAM overhead (critical on old hardware)
+2. It keeps the Linux-native development experience (nginx, systemd, bash scripts are well-documented and version-controllable)
+3. The .NET runtime runs at full native speed without container indirection
+4. systemd gives robust process supervision (auto-restart, logging, dependency management)
+5. Cloudflare Tunnel handles all the hard networking problems (TLS, DDoS, IP hiding, port blocking)
+
+If the laptop is extremely resource-constrained (4GB RAM or less), consider Approach 3 (IIS) to eliminate the WSL2 VM overhead entirely. If you value operational simplicity and keeping the same artifact as production, go with Approach 1 (Docker).
+
+---
+
+## Appendix: Terraform Cleanup
+
+After migration, destroy the AWS resources to stop billing. Keep only what's still needed:
+
+```bash
+# Set enable_compute = false in terraform.tfvars for both environments
+# (This is already the current state, so nothing to change)
+
+# Resources that will remain destroyed:
+# - ECS services + tasks
+# - ALB + target groups + listeners
+# - NAT Gateways + Elastic IPs
+# - API Route53 A records
+# - CloudWatch dashboards
+
+# Resources you may still want:
+# - S3 + CloudFront (keep as cold standby / rollback option)
+# - ECR (keep if using Docker images)
+# - VPC/Subnets (can't delete with Terraform managed, leave as-is)
+# - SSM Parameters (keep as source of truth for secrets)
+
+# If you want to fully clean up:
+cd terraform/environments/staging
+terraform destroy -var="enable_compute=false"
+
+cd terraform/environments/production
+terraform destroy -var="enable_compute=false"
+```
+
+**Warning:** Full `terraform destroy` will delete:
+- S3 buckets (and all frontend files)
+- CloudFront distributions
+- ECR repositories (and all images)
+- SSM parameters (your secrets!)
+- VPCs and all networking
+
+Export SSM parameter values before destroying, and consider keeping S3 + CloudFront as a cheap (~$2/mo) rollback option.

--- a/agentic-claude-infra/wsl2-native-implementation-plan.md
+++ b/agentic-claude-infra/wsl2-native-implementation-plan.md
@@ -1,0 +1,2487 @@
+# WSL2 Native Implementation Plan
+
+## Target Audience
+
+You have cloud-native experience (AWS ECS, ALB, S3, Route53, Terraform) but limited
+experience with Linux, WSL2, nginx, systemd, or Cloudflare. This guide maps every concept
+back to what you already know.
+
+---
+
+## Table of Contents
+
+1. [Architecture Overview](#1-architecture-overview)
+2. [Concept Mapping: Cloud → Linux](#2-concept-mapping-cloud--linux)
+3. [Prerequisites](#3-prerequisites)
+4. [Phase 1: WSL2 Setup](#4-phase-1-wsl2-setup)
+5. [Phase 2: Install the Stack](#5-phase-2-install-the-stack)
+6. [Phase 3: Deploy the Backend](#6-phase-3-deploy-the-backend)
+7. [Phase 4: Configure Nginx](#7-phase-4-configure-nginx)
+8. [Phase 5: Process Supervision with systemd](#8-phase-5-process-supervision-with-systemd)
+9. [Phase 6: Cloudflare Tunnel — How It Works](#9-phase-6-cloudflare-tunnel--how-it-works)
+10. [Phase 7: Cloudflare Tunnel — Setup](#10-phase-7-cloudflare-tunnel--setup)
+11. [Phase 8: TLS Termination](#11-phase-8-tls-termination)
+12. [Phase 9: DNS Migration](#12-phase-9-dns-migration)
+13. [Phase 10: CI/CD Pipeline (Dual-Mode)](#13-phase-10-cicd-pipeline-dual-mode)
+14. [Phase 11: Staging Environment](#14-phase-11-staging-environment)
+15. [Phase 12: Monitoring & Alerts](#15-phase-12-monitoring--alerts)
+16. [Phase 13: Maintenance & Day-2 Operations](#16-phase-13-maintenance--day-2-operations)
+17. [Troubleshooting Guide](#17-troubleshooting-guide)
+18. [Full File Reference](#18-full-file-reference)
+
+---
+
+## 1. Architecture Overview
+
+### What Moves, What Stays
+
+```
+                         BEFORE (all AWS)                      AFTER (hybrid)
+                    ┌──────────────────────┐           ┌──────────────────────┐
+                    │                      │           │                      │
+  Users ───────────▶│  CloudFront CDN      │           │  CloudFront CDN      │  ← STAYS on AWS
+                    │  (Angular static)    │           │  (Angular static)    │
+                    │                      │           │                      │
+                    │  S3 (frontend files) │           │  S3 (frontend files) │
+                    │                      │           │                      │
+                    └──────────────────────┘           └──────────────────────┘
+                    
+                    ┌──────────────────────┐           ┌──────────────────────┐
+                    │                      │           │  OLD WINDOWS LAPTOP  │
+  Users ───────────▶│  ALB (HTTPS)         │           │  ┌────────────────┐  │
+                    │        │             │           │  │ Cloudflare     │  │
+                    │        ▼             │           │  │ Tunnel         │  │
+                    │  ECS Fargate         │           │  │ (outbound)     │  │
+                    │  (.NET API)          │           │  └───────┬────────┘  │
+                    │        │             │           │          ▼           │
+                    │        ▼             │           │  ┌────────────────┐  │
+                    │  Aiven MySQL         │           │  │ nginx (8080)   │  │  ← MOVES to laptop
+                    │  Redis Cloud         │           │  │ API proxy only │  │
+                    │                      │           │  └───────┬────────┘  │
+                    └──────────────────────┘           │          ▼           │
+                                                       │  ┌────────────────┐  │
+                                                       │  │ .NET API       │  │
+                                                       │  │ systemd svc    │  │
+                                                       │  │ (port 5163)    │  │
+                                                       │  └────────────────┘  │
+                                                       └──────────────────────┘
+                    
+                    ┌──────────────────────┐           ┌──────────────────────┐
+                    │  ACM (TLS cert)      │           │  Cloudflare DNS      │  ← MOVES
+                    │  Route53 (DNS)       │           │  + Edge Cert (TLS)   │
+                    └──────────────────────┘           └──────────────────────┘
+```
+
+**Frontend:** Stays exactly as-is on S3 + CloudFront. Zero changes. AWS handles CDN,
+caching, and TLS for static assets.
+
+**Backend:** Moves off ECS Fargate onto the laptop. Cloudflare Tunnel provides secure
+ingress without opening ports. nginx acts as a lightweight reverse proxy (API only, no
+static files).
+
+---
+
+## 2. Concept Mapping: Cloud → Linux
+
+Before you type a single command, understand what each AWS service maps to:
+
+| AWS Service | What It Does | Linux/WSL2 Equivalent |
+|---|---|---|
+| **ECS Fargate** | Runs your container, restarts it if it crashes | **systemd service** — a unit file that tells Linux to run your .NET app and restart it if it dies |
+| **ALB (Application Load Balancer)** | Receives HTTPS traffic, routes to backend, health checks | **nginx** — listens on port 8080, proxies all requests to the backend API |
+| **ACM (Certificate Manager)** | TLS certificate, auto-renews | **Cloudflare edge certificate** — auto-provisioned, no renewal needed |
+| **Route53** | DNS records pointing to ALB/CloudFront | **Cloudflare DNS** — same concept, different UI |
+| **SSM Parameter Store** | Stores secrets, injects as env vars | **`.env` file** — plain text file with `KEY=VALUE`, read by systemd |
+| **Security Group** | Allows port 443 from 0.0.0.0/0 | **Cloudflare Tunnel** — no open ports needed, Cloudflare reaches IN to your laptop |
+| **NAT Gateway** | Lets private subnets reach the internet | **Your home router** — already does NAT, nothing to configure |
+| **CloudWatch Logs** | Centralized log storage | **journald** — built into Linux, captures all service stdout/stderr |
+| **ECR** | Stores Docker images | **Not needed** — you run the compiled `.dll` directly, no container |
+| **Health check (ALB)** | `GET /health` → 200 OK | **nginx health check** or external monitoring via Uptime Kuma |
+
+> **S3 + CloudFront stay in AWS unchanged.** The frontend does not move. This plan
+> only migrates the backend API. Static assets continue to be served from S3 via
+> CloudFront exactly as they are today.
+
+### Key Networking Difference
+
+```
+AWS (what you have now):
+  User → CloudFront/S3 (frontend)
+  User → ALB (HTTPS) → ECS Fargate (port 5163)
+
+Hybrid (what you're building):
+  User → CloudFront/S3 (frontend)          ← UNCHANGED
+  User → Cloudflare DNS
+       → Cloudflare Tunnel (outbound from laptop to Cloudflare)
+       → nginx on laptop (port 8080)
+       → .NET backend on laptop (port 5163, localhost only)
+```
+
+The critical insight: **nothing reaches your laptop directly.** Cloudflare Tunnel
+creates an outbound connection from your laptop to Cloudflare's edge. User traffic
+hits Cloudflare, Cloudflare sends it back through that tunnel. Your home IP is hidden
+and no ports need to be forwarded.
+
+---
+
+## 3. Prerequisites
+
+### Hardware
+
+- Old Windows laptop (Windows 10 version 2004+ or Windows 11)
+- 4GB RAM minimum (2GB allocated to WSL2), 8GB recommended
+- 20GB free disk space
+- Laptop plugged into power 24/7 (set power settings to never sleep)
+
+### Accounts
+
+- **Cloudflare account** (free tier) — you'll migrate DNS here from Route53
+- **GitHub account** — already using this
+- Domain: `qawitherev.com` (move from Route53 to Cloudflare)
+
+### Software (on the laptop)
+
+- Windows Terminal (install from Microsoft Store — much better than the default console)
+- A code editor (VS Code recommended — it has excellent WSL2 integration)
+
+### Knowledge Prerequisites
+
+This guide assumes you can:
+- Open PowerShell as Administrator
+- SSH into a server (conceptually — you won't actually SSH here)
+- Read YAML/JSON configuration
+- Understand what an environment variable is
+
+---
+
+## 4. Phase 1: WSL2 Setup
+
+**Goal:** Get a Linux environment running inside Windows.
+
+### What is WSL2?
+
+Windows Subsystem for Linux 2 runs a real Linux kernel inside a lightweight VM.
+Unlike a traditional VM (VirtualBox, VMware), WSL2:
+- Starts in under 2 seconds
+- Uses only the RAM it needs (dynamically allocates)
+- Lets you access Linux files from Windows (`\\wsl$\`) and Windows files from Linux (`/mnt/c/`)
+- Integrates with VS Code (`code .` from inside WSL2 opens VS Code on Windows)
+
+Think of it like this: ECS Fargate runs your container in a micro-VM (Firecracker).
+WSL2 runs Ubuntu in a similar lightweight VM. Same concept.
+
+### Step 3.1: Install WSL2
+
+Open **PowerShell as Administrator** (right-click Start → Terminal (Admin)):
+
+```powershell
+# Install WSL2 with Ubuntu 24.04
+wsl --install -d Ubuntu-24.04
+```
+
+This command does four things automatically:
+1. Enables the Windows Subsystem for Linux feature
+2. Enables the Virtual Machine Platform feature
+3. Downloads and installs the Linux kernel
+4. Downloads and installs Ubuntu 24.04
+
+After it finishes, **restart your computer**.
+
+On first boot after restart, a terminal window will open asking you to create a
+Linux username and password. Pick something simple (e.g., username: `qawitherev`, password: something memorable).
+
+```
+Installing, this may take a few minutes...
+Please create a default UNIX user account. The username does not need to match your Windows username.
+Enter new UNIX username: qawitherev
+New password: ********
+Retype new password: ********
+```
+
+**Important Linux concept:** When you type your password in Linux, nothing appears on
+screen (no dots, no asterisks). This is normal — it's still receiving your input. Type
+blindly and press Enter.
+
+### Step 3.2: Limit WSL2 Memory
+
+WSL2 can consume up to 80% of your host RAM by default. On an old laptop, you want
+to cap this.
+
+Open PowerShell (not as admin this time) and create a config file:
+
+```powershell
+notepad "$env:USERPROFILE\.wslconfig"
+```
+
+Paste this:
+
+```ini
+[wsl2]
+memory=2GB
+processors=2
+swap=2GB
+
+[boot]
+systemd=true
+```
+
+What each line means:
+
+| Setting | What It Does |
+|---|---|
+| `memory=2GB` | Caps the WSL2 VM at 2GB RAM. Your .NET app idles around 150MB, so 2GB is plenty. |
+| `processors=2` | Limits WSL2 to 2 CPU cores. Prevents the VM from hogging all cores during builds. |
+| `swap=2GB` | If WSL2 runs out of RAM, it can use 2GB of disk as overflow. Slow but prevents crashes. |
+| `systemd=true` | **Critical.** Enables systemd (Linux's init system). Without this, you can't run services that auto-start and auto-restart. Think of systemd as the "ECS control plane" for your laptop. |
+
+Apply the settings by restarting WSL2:
+
+```powershell
+wsl --shutdown
+```
+
+Then open Ubuntu again from the Start menu. (WSL2 boots fresh on the first terminal open.)
+
+### Step 3.3: Update Ubuntu
+
+Open an Ubuntu terminal (from Start menu, or type `wsl` in PowerShell) and run:
+
+```bash
+# apt is Ubuntu's package manager. Think of it like npm/nuget but for system software.
+# "update" refreshes the list of available packages (doesn't install anything)
+sudo apt update
+
+# "upgrade" installs newer versions of everything already installed
+# "-y" means "answer yes to all prompts" (no interactive confirmation)
+sudo apt upgrade -y
+```
+
+**What is `sudo`?** It means "super user do" — run this command as root (the Linux
+equivalent of Administrator). You'll be prompted for the password you created in Step 3.1.
+
+### Step 3.4: Understand the Filesystem
+
+```
+Windows:  C:\Users\abdulqawi\Documents\
+WSL2:     /home/qawitherev/                  (your Linux home directory)
+          /mnt/c/Users/abdulqawi/Documents/  (same Windows folder, accessed from Linux)
+```
+
+**Rule of thumb:**
+- Store Linux app files (backend, nginx configs) in `/home/qawitherev/` or `/opt/`
+- Access Windows files via `/mnt/c/` only when you need to share files
+- **Never** put your project files in `/mnt/c/` and run them from there — it's extremely slow due to cross-filesystem translation. Clone your repo inside WSL2.
+
+### Phase 1 Verification
+
+```bash
+# All of these should work without errors:
+wsl --version          # (from PowerShell) Should show WSL version 2.x
+uname -r               # (from Ubuntu) Should show a Linux kernel version
+systemctl --version    # (from Ubuntu) Should show systemd version
+free -h                # (from Ubuntu) Should show ~1.9Gi total memory
+```
+
+---
+
+## 5. Phase 2: Install the Stack
+
+**Goal:** Install .NET 9.0 runtime, nginx, and cloudflared inside WSL2.
+
+### Step 4.1: Install .NET 9.0 SDK
+
+Unlike AWS where you use a Docker image with the runtime baked in, you install the
+SDK directly on the OS. The SDK includes the runtime — you don't need both.
+
+```bash
+# 1. Add Microsoft's package repository (so apt knows where to download .NET)
+#    This is like adding a NuGet source, but for system packages
+#    THIS MUST COME FIRST — without it, apt has no idea what "dotnet-sdk-9.0" is
+wget https://packages.microsoft.com/config/ubuntu/24.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+sudo dpkg -i packages-microsoft-prod.deb
+
+# 2. Refresh package list with the new Microsoft repo included
+sudo apt update
+
+# 3. Install the .NET 9.0 SDK
+#    The SDK includes the runtime, so this is all you need
+#    (it pulls in aspnetcore-runtime-9.0 as a dependency)
+sudo apt install -y dotnet-sdk-9.0
+```
+
+The Terraform ECS task definition does this via the Docker image (`mcr.microsoft.com/dotnet/aspnet:9.0`).
+Installing the SDK directly is the same thing, just without the container — plus it gives you
+the build tools (`dotnet publish`, `dotnet test`, etc.).
+
+Verify:
+
+```bash
+dotnet --version         # Should print 9.0.x
+dotnet --list-runtimes   # Shows all installed runtimes (aspnetcore-runtime-9.0 should be listed)
+```
+
+### Step 4.2: Install nginx
+
+```bash
+sudo apt install -y nginx curl
+```
+
+nginx is now running! Check it:
+
+```bash
+# "systemctl status" = "what's the state of this service?"
+# Like checking the ECS service dashboard for "running tasks: 1/1"
+sudo systemctl status nginx
+```
+
+You should see `Active: active (running)`. Press `q` to exit the status screen.
+
+**Stop nginx for now** — you don't want it running on the default config:
+
+```bash
+sudo systemctl stop nginx
+sudo systemctl disable nginx    # Don't auto-start on boot (yet)
+```
+
+**nginx concepts mapped to ALB:**
+
+| nginx Concept | ALB Equivalent |
+|---|---|
+| `server` block | An ALB listener (e.g., port 443) |
+| `proxy_pass http://127.0.0.1:5163` | Forward to target group |
+| `listen 8080` | The port nginx binds to (like ALB listening on 443) |
+| `limit_req_zone` | AWS WAF rate-based rule |
+
+> nginx is a **pure API reverse proxy** in this setup. The frontend stays on
+> S3 + CloudFront — nginx does not serve static files.
+
+### Step 4.3: Install cloudflared
+
+#### The Problem
+
+Your laptop is behind a home router. It has a private IP like `192.168.1.5`.
+The internet cannot reach it directly. In AWS, your ALB has a public IP — DNS
+points to it and traffic flows in. Your laptop doesn't have that.
+
+Traditionally you'd need to:
+1. Get a static public IP from your ISP
+2. Configure port forwarding on your router (443 → laptop)
+3. Hope your ISP doesn't block port 443 (many do)
+
+Cloudflare Tunnel eliminates all three. It does this by **reversing the direction.**
+
+#### How It Works (Simple Example)
+
+Imagine you're in a hotel room with no phone number and the front desk won't
+forward calls to you. How does anyone reach you?
+
+**Without the tunnel:** Someone needs your direct number (public IP). You don't
+have one. Dead end.
+
+**With the tunnel:** You call the front desk first and say "I'm expecting visitors
+for 'parcel-management', send them to my room." Now when someone shows up at the
+front desk asking for "parcel-management", the front desk forwards them through
+the call YOU initiated. You called out, so the hotel phone system allows it.
+
+cloudflared is you calling the front desk. Cloudflare's edge is the front desk.
+The visitor is your user.
+
+#### Visual Comparison
+
+```
+TRADITIONAL (how AWS works):            CLOUDFLARE TUNNEL (how the laptop works):
+
+User ──→ public IP ──→ ALB              User ──→ Cloudflare Edge
+         (port 443         │                      │
+          is OPEN)         │                      │  "I know this domain.
+                           ▼                      │   Tunnel abc123 is
+                         ECS Fargate              │   waiting for it."
+                                                  │
+                         TRAFFIC FLOWS IN         │
+                         (inbound)                ▼
+                                            Cloudflare ──→ cloudflared ──→ nginx
+                                            Edge           (on laptop)      (port 8080)
+                                            │
+                                            │  The laptop called Cloudflare FIRST.
+                                            │  This connection is OUTBOUND, so the
+                                            │  router allows it — just like browsing
+                                            │  the web.
+                                            │
+                                            TRAFFIC FLOWS OUT, THEN BACK IN
+                                            (outbound-initiated)
+```
+
+```
+WHAT ACTUALLY HAPPENS (moment by moment):
+
+MOMENT 1 — Tunnel starts:
+  Laptop ──"I'm tunnel abc123. Send me traffic for api.parcel-management..."──→ Cloudflare
+  (OUTBOUND — router sees this as "browsing the web", allows it)
+
+MOMENT 2 — User visits https://api-parcel-management.qawitherev.com/health:
+  User ──→ Cloudflare DNS resolves to Cloudflare IPs (NOT your home IP)
+  User ──→ Cloudflare Edge "Give me /health for api.parcel-management..."
+  Cloudflare checks: "api.parcel-management → tunnel abc123 → the laptop is connected"
+  Cloudflare forwards the request through the already-open outbound connection
+  cloudflared receives it → nginx:8080 → .NET:5163
+
+Your home IP is never in DNS. No ports are open on your router.
+The entire world sees Cloudflare IPs, not yours.
+```
+
+#### What This Replaces From AWS
+
+| AWS Component | Replaced By |
+|---|---|
+| ALB (public endpoint) | Cloudflare Edge + nginx on laptop |
+| Security Group (allow port 443) | Nothing — zero inbound ports needed |
+| Elastic IP | Nothing — your IP is never exposed |
+| ACM (TLS certificate) | Cloudflare auto-provisioned edge cert |
+
+#### Installation
+
+```bash
+# Download the latest cloudflared
+curl -L https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb -o cloudflared.deb
+
+# Install it
+sudo dpkg -i cloudflared.deb
+
+# Verify
+cloudflared --version
+```
+
+You won't configure cloudflared yet — that comes in Phase 7 after the backend and
+nginx are running. For now, just having it installed is enough.
+
+### Phase 2 Verification
+
+```bash
+dotnet --version           # 9.0.x
+nginx -v                   # nginx version: 1.x.x
+cloudflared --version      # cloudflared version 20xx.x.x
+systemctl --version        # systemd 255
+```
+
+---
+
+## 6. Phase 3: Deploy the Backend
+
+**Goal:** Get the .NET API running on the laptop at `http://127.0.0.1:5163/health`.
+
+### Step 5.1: Choose Your Deployment Strategy
+
+You have two options. Pick one before continuing:
+
+**Option A — Build on the laptop (simpler, slower builds):**
+Clone the repo in WSL2, run `dotnet publish` on the laptop. Every deploy does a full build.
+Recommended if: you want the simplest setup and don't mind 2-4 minute builds.
+
+**Option B — Build in GitHub Actions, download artifacts (faster, more moving parts):**
+GitHub Actions builds the app, creates a `.tar.gz` artifact. The laptop downloads and extracts it.
+Recommended if: you want faster deployments and the laptop is very slow.
+
+This guide follows **Option A** for simplicity. If you prefer Option B, see the
+CI/CD section (Phase 10) for the artifact-based workflow.
+
+### Step 5.2: Clone the Repository
+
+```bash
+# Stay in your home directory
+cd ~
+
+# Clone the repo. Use HTTPS if you haven't set up SSH keys.
+git clone https://github.com/qawitherev/parcel-management-system.git
+
+# Navigate to the backend source
+cd ~/parcel-management-system/backend/src
+```
+
+### Step 5.3: Build and Publish
+
+```bash
+# "dotnet publish" = compile + bundle everything needed to run
+# -c Release     = Release configuration (optimized, no debug symbols)
+# -o ~/pm/backend = output directory (temporary — will be moved to /opt)
+
+dotnet publish ParcelManagement.Api -c Release -o ~/pm/backend
+```
+
+This is the same thing your Dockerfile does, minus the container:
+```
+Dockerfile:    dotnet publish → COPY to /app → docker run
+WSL2 Native:   dotnet publish → run directly with `dotnet ParcelManagement.Api.dll`
+```
+
+After it finishes, verify the output:
+
+```bash
+ls ~/pm/backend/
+# Should show: ParcelManagement.Api.dll, web.config, appsettings.json, and many more files
+```
+
+> **⚠️ Important:** The backend must live in `/opt/pm/backend/`, NOT in `/home/<user>/pm/backend/`.
+> The systemd service uses `ProtectHome=yes` which blocks all `/home/` access for security.
+> `/opt/` is the Linux convention for installed applications and is not restricted by this rule.
+> See Step 5.6 for the move.
+
+### Step 5.4: Test the Backend Manually
+
+```bash
+# Run the app from the output directory, NOT as root
+cd ~/pm/backend
+
+# Set the URL and environment inline
+ASPNETCORE_URLS="http://127.0.0.1:5163" \
+ASPNETCORE_ENVIRONMENT="Production" \
+dotnet ParcelManagement.Api.dll
+```
+
+You'll see output like:
+```
+info: Microsoft.Hosting.Lifetime[14]
+      Now listening on: http://127.0.0.1:5163
+info: Microsoft.Hosting.Lifetime[0]
+      Application started. Press Ctrl+C to shut down.
+```
+
+**Open a second Ubuntu terminal** (or split your existing one) and test the health endpoint:
+
+```bash
+curl http://127.0.0.1:5163/health
+# Should return: Healthy (or a 200 status with a JSON response)
+```
+
+If this works, press `Ctrl+C` in the first terminal to stop the app. You've confirmed
+the app runs. Now you need to make it run as a managed service.
+
+**Note:** The app likely failed because it's missing environment variables (database
+connection string, JWT key, etc.). That's expected. You set those up next.
+
+### Step 5.5: Set Up Environment Variables
+
+Create the environment file. This replaces AWS SSM Parameter Store.
+
+```bash
+# Create the config directory (owned by root, readable only by root and the service user)
+sudo mkdir -p /etc/parcel-management
+sudo touch /etc/parcel-management/.env
+```
+
+Now edit the file:
+
+```bash
+sudo nano /etc/parcel-management/.env
+```
+
+(`nano` is a simple terminal text editor. `Ctrl+O` to save, `Ctrl+X` to exit. VS Code
+users: you can also use `code` to open VS Code on Windows for WSL2 files.)
+
+Paste all your environment variables into this file:
+
+```bash
+# ────────────────────────────────────────────
+# Parcel Management API — Environment Variables
+# (Formerly in AWS SSM Parameter Store)
+# ────────────────────────────────────────────
+
+# Database (Aiven MySQL)
+ConnectionStrings__DefaultConnection="Server=mysql-7d076dd-qawitherev-hobby-projects.h.aivencloud.com;Port=22115;Database=parcel-management-system;User=avnadmin;Password=YOUR_AVNEN_ADMIN_PASSWORD;SslMode=VerifyCA;SslCa=/tmp/ca.pem"
+
+# JWT Settings
+JWTSettings__SecretKey=YOUR_JWT_SECRET_KEY
+JWTSettings__Issuer=ParcelManagement
+JWTSettings__Audience=ParcelManagement
+JWTSettings__ExpirationMinutes=60
+
+# Notification (SendGrid)
+Notification__Email__Password=YOUR_SENDGRID_API_KEY
+Notification__Email__Username=apikey
+Notification__Email__SmtpHost=smtp.sendgrid.net
+Notification__Email__SmtpPort=587
+Notification__Email__FromAddress=noreply@qawitherev.com
+
+# Redis (Redis Cloud)
+RedisSettings__ConnectionString=YOUR_REDIS_CONNECTION_STRING
+
+# Admin
+Admin__Email=admin@parcelmanagement.com
+Admin__Password=YOUR_ADMIN_PASSWORD
+
+# CORS
+AllowedOrigins=https://parcel-management.qawitherev.com
+
+# ASP.NET Core
+ASPNETCORE_URLS=http://127.0.0.1:5163
+ASPNETCORE_ENVIRONMENT=Production
+
+# CA Certificate for Aiven MySQL TLS
+DbCACert="-----BEGIN CERTIFICATE-----
+YOUR_CA_CERTIFICATE_CONTENT_HERE
+-----END CERTIFICATE-----"
+```
+
+**Where to get these values:**
+
+Run this AWS CLI command to fetch all your SSM parameters (do this BEFORE destroying
+anything in AWS, or from your local machine that has AWS credentials):
+
+```powershell
+# From PowerShell (or run from inside WSL2 if you have the AWS CLI installed)
+aws ssm get-parameters-by-path \
+    --path "/production/backend/" \
+    --with-decryption \
+    --region ap-southeast-1 \
+    --query "Parameters[*].[Name,Value]" \
+    --output text
+```
+
+Replace `production` with `staging` for staging env vars.
+
+**Secure the .env file:**
+
+```bash
+# Set ownership to root only
+sudo chown root:root /etc/parcel-management/.env
+
+# Only root can read it (600 = owner read+write, nobody else can read)
+sudo chmod 600 /etc/parcel-management/.env
+```
+
+This is the Linux equivalent of an SSM SecureString — only privileged processes can read it.
+
+### Step 5.6: Create the Service User
+
+ECS runs your container as an isolated user. You'll create a dedicated Linux user for the
+same purpose:
+
+```bash
+# Create a system user (no login shell, no home directory)
+# -r = system user (UID < 1000)
+# -s /bin/false = can never log in interactively
+sudo useradd -r -s /bin/false pm-svc
+
+# Move the backend to /opt (Linux convention for installed applications)
+# /opt/ is NOT protected by ProtectHome=yes, unlike /home/ directories
+sudo mkdir -p /opt/pm
+sudo mv ~/pm/backend /opt/pm/backend
+sudo chown -R pm-svc:pm-svc /opt/pm/backend
+```
+
+### Step 5.7: Write the CA Certificate
+
+The MySQL connection uses TLS with a CA certificate. Your ECS task injects it via
+the `DbCACert` environment variable. The backend code likely writes it to `/tmp/ca.pem`
+at startup. However, to be safe, also write it as an actual file:
+
+```bash
+# Extract the CA cert from the env var and write to a file
+# (Run this after the .env file is created)
+source /etc/parcel-management/.env
+echo "$DbCACert" | sudo tee /tmp/ca.pem > /dev/null
+sudo chmod 644 /tmp/ca.pem
+```
+
+---
+
+## 7. Phase 4: Configure Nginx
+
+**Goal:** nginx listens on port 8080 and proxies all requests to the .NET backend.
+
+> **Frontend is NOT served from here.** nginx is a pure API reverse proxy. The
+> Angular frontend stays on S3 + CloudFront as-is. This keeps nginx lean and avoids
+> duplicating what CloudFront already does well.
+
+### Step 7.1: Create the nginx Configuration
+
+nginx configuration works like this:
+- `/etc/nginx/nginx.conf` — main config (don't touch this)
+- `/etc/nginx/sites-available/` — all possible site configs
+- `/etc/nginx/sites-enabled/` — symlinks to configs you want ACTIVE
+
+This is like having Terraform modules: `sites-available/` is your module source,
+`sites-enabled/` is the `terraform apply` — it's what's actually live.
+
+Create the site config:
+
+```bash
+sudo nano /etc/nginx/sites-available/parcel-management
+```
+
+Paste this:
+
+```nginx
+# ────────────────────────────────────────────
+# Rate limiting zone (shared memory zone for tracking request rates)
+# $binary_remote_addr = client IP (4 bytes, very efficient)
+# zone=api:10m       = 10MB shared memory for this zone (~160k IPs)
+# rate=30r/s         = 30 requests per second per IP
+# ────────────────────────────────────────────
+limit_req_zone $binary_remote_addr zone=api:10m rate=30r/s;
+
+server {
+    # Listen on port 8080 (cloudflared will tunnel to this)
+    listen 8080;
+    server_name _;
+
+    # ─── Gzip Compression ───────────────────
+    gzip on;
+    gzip_types application/json;
+
+    # ─── Security Headers ───────────────────
+    add_header X-Frame-Options "DENY" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+    # ─── API Proxy ──────────────────────────
+    location / {
+        # Apply rate limit
+        limit_req zone=api burst=20 nodelay;
+
+        # Forward to backend
+        proxy_pass http://127.0.0.1:5163;
+
+        # Pass through request details
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection keep-alive;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $http_x_forwarded_for;
+        proxy_set_header X-Forwarded-For $http_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Timeout after 60 seconds
+        proxy_read_timeout 60s;
+    }
+}
+```
+
+### Step 7.2: Enable the Site
+
+```bash
+# Create a symlink (shortcut) from sites-enabled to sites-available
+# This "activates" the config
+sudo ln -s /etc/nginx/sites-available/parcel-management /etc/nginx/sites-enabled/
+
+# Remove the default "Welcome to nginx" site
+sudo rm /etc/nginx/sites-enabled/default
+
+# Check that the config syntax is valid
+sudo nginx -t
+# Should print: "syntax is ok" and "test is successful"
+
+# Reload nginx (applies new config without dropping connections)
+sudo systemctl reload nginx
+
+# Enable auto-start on boot
+sudo systemctl enable nginx
+```
+
+### Step 7.3: Test nginx
+
+```bash
+# Test the health endpoint through nginx
+curl http://127.0.0.1:8080/health
+# Should return: Healthy (or 200 OK) once the backend is running
+# If backend isn't running yet: 502 Bad Gateway (nginx is working, but can't reach backend — expected!)
+
+# Test any API endpoint
+curl http://127.0.0.1:8080/api/some-endpoint
+# Same behavior — nginx proxies everything to the backend
+```
+
+**nginx concepts mapped to ALB:**
+
+| nginx Concept | ALB Equivalent |
+|---|---|
+| `server` block | An ALB listener (e.g., port 443) |
+| `proxy_pass http://127.0.0.1:5163` | Forward to target group |
+| `listen 8080` | The port nginx binds to (like ALB listening on 443) |
+| `limit_req_zone` | AWS WAF rate-based rule |
+
+---
+
+## 8. Phase 5: Process Supervision with systemd
+
+**Goal:** Make the backend start automatically on boot and restart if it crashes.
+
+### What is systemd?
+
+systemd is the init system for Ubuntu. It manages services (start, stop, restart, logs,
+dependencies). Think of it as ECS's control plane:
+
+| systemd Concept | ECS Equivalent |
+|---|---|
+| Unit file (`.service`) | Task definition |
+| `systemctl start pm-api` | `aws ecs run-task` |
+| `systemctl enable pm-api` | Create an ECS service (maintain desired count) |
+| `Restart=always` | ECS service auto-healing (replace failed tasks) |
+| `journalctl -u pm-api` | CloudWatch Logs for a specific log group |
+| `After=network.target` | Container dependency ordering |
+
+### Step 7.1: Create the systemd Service Unit
+
+```bash
+sudo nano /etc/systemd/system/pm-api.service
+```
+
+Paste this:
+
+```ini
+[Unit]
+Description=Parcel Management API (.NET 9.0)
+Documentation=https://github.com/qawitherev/parcel-management-system
+After=network.target
+# "After=network.target" means: wait until networking is ready before starting
+
+[Service]
+# ─── Process Configuration ──────────────────
+Type=simple
+# "simple" = systemd considers the service started once the process is spawned
+# "notify" would be better (.NET supports it) but "simple" works fine
+
+User=pm-svc
+Group=pm-svc
+# Runs as the dedicated service user, not root (security best practice)
+
+WorkingDirectory=/opt/pm/backend
+# Where the .dll files live
+
+EnvironmentFile=/etc/parcel-management/.env
+# Load environment variables from this file
+
+ExecStart=/usr/bin/dotnet /opt/pm/backend/ParcelManagement.Api.dll
+# The actual command to run. /usr/bin/dotnet is the full path to the dotnet executable.
+# Find it yourself with: which dotnet
+
+# ─── Restart Policy ─────────────────────────
+Restart=always
+# Always restart if the process dies (like ECS service with desired count = 1)
+RestartSec=10
+# Wait 10 seconds before restarting (prevents crash loops from hammering the system)
+# In Docker terms: restart: unless-stopped
+# In ECS terms: this is the service scheduler
+
+# ─── Logging ────────────────────────────────
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=pm-api
+# All console output goes to journald (Linux's built-in log system)
+# Equivalent to: CloudWatch Logs with log group /ecs/parcel-management-system
+
+# ─── Security Hardening ─────────────────────
+NoNewPrivileges=yes
+# Prevents the process from gaining new privileges (like running sudo)
+# Similar to: ECS task definition "privileged: false"
+
+ProtectSystem=strict
+# Makes the entire filesystem read-only except for explicit exceptions
+# Similar to: Docker read-only root filesystem
+
+ProtectHome=yes
+# Prevents access to /home directories (the backend lives in /opt, not /home)
+
+ReadWritePaths=/opt/pm/backend /tmp
+# Even with ProtectSystem=strict, allow writes to these paths
+# The backend writes logs? Needs /tmp for the CA cert
+
+PrivateTmp=yes
+# Gives the service its own private /tmp directory (isolated from other services)
+
+[Install]
+WantedBy=multi-user.target
+# "multi-user.target" = the normal boot target (like runlevel 3)
+# This means: start this service when the system reaches multi-user mode
+# Equivalent to: ECS service with desiredCount=1 (auto-starts and stays running)
+```
+
+### Step 7.2: Start the Service
+
+```bash
+# Tell systemd to reload its configuration (it scans /etc/systemd/system/ for new files)
+sudo systemctl daemon-reload
+
+# Start the service
+sudo systemctl start pm-api
+
+# Check if it's running
+sudo systemctl status pm-api
+# Look for: Active: active (running)
+# If it says "failed" or "inactive", check the logs (next step)
+
+# Enable auto-start on boot
+sudo systemctl enable pm-api
+```
+
+### Step 7.3: Check the Logs
+
+```bash
+# View the last 50 lines of logs for the pm-api service
+sudo journalctl -u pm-api -n 50 --no-pager
+
+# Follow logs in real-time (like tail -f, or CloudWatch Logs Live Tail)
+sudo journalctl -u pm-api -f
+
+# View logs since last boot
+sudo journalctl -u pm-api -b
+
+# View logs from a specific time
+sudo journalctl -u pm-api --since "2026-05-24 18:00:00"
+```
+
+**What to look for in the logs:**
+```
+info: Microsoft.Hosting.Lifetime[14]
+      Now listening on: http://127.0.0.1:5163         ← Good
+info: Microsoft.Hosting.Lifetime[0]
+      Application started. Press Ctrl+C to shut down.  ← Good
+
+fail: Microsoft.EntityFrameworkCore.Database.Connection[20004]
+      An error occurred using the connection to database... ← Bad (check connection string)
+
+Unhandled exception. System.InvalidOperationException... ← Bad (app crashed)
+```
+
+### Step 7.4: Verify the Full Chain
+
+```bash
+# 1. Verify backend is listening on its port
+curl http://127.0.0.1:5163/health
+# Should return: Healthy (or 200 OK)
+# If not: sudo systemctl status pm-api to see if the service is running
+
+# 2. Verify nginx proxies to the backend
+curl http://127.0.0.1:8080/health
+# Should return: Healthy (same as above)
+
+# If both work, the local stack is healthy.
+```
+
+### Step 7.5: Important systemd Commands Cheat Sheet
+
+```bash
+sudo systemctl start pm-api       # Start the service
+sudo systemctl stop pm-api        # Stop the service
+sudo systemctl restart pm-api     # Stop + start (new process)
+sudo systemctl reload pm-api      # Reload config without restarting (if the app supports it)
+sudo systemctl status pm-api      # Is it running? Any errors?
+sudo systemctl enable pm-api      # Auto-start on boot
+sudo systemctl disable pm-api     # Don't auto-start on boot
+sudo systemctl is-active pm-api   # Prints "active" or "inactive"
+sudo systemctl is-enabled pm-api  # Prints "enabled" or "disabled"
+
+# After editing any .service file:
+sudo systemctl daemon-reload      # Reload systemd configuration
+sudo systemctl restart pm-api     # Apply changes
+```
+
+---
+
+## 9. Phase 6: Cloudflare Tunnel — How It Works
+
+**Read this before you run any commands.** Phase 7 is the hands-on setup. This phase
+explains what's actually happening so the setup makes sense.
+
+### The Problem Cloudflare Tunnel Solves
+
+In AWS, your ALB has a **public IP address**. DNS points your domain at that IP.
+Traffic flows IN:
+
+```
+User → DNS lookup → ALB public IP → ECS (private subnet)
+```
+
+Your laptop is behind a home router. It has a private IP like `192.168.1.5`.
+The internet can't reach it. Traditionally you'd need:
+
+1. A static private IP on the laptop
+2. **Port forwarding** on your router (443 → `192.168.1.5:8080`)
+3. A **static public IP** from your ISP (or DDNS)
+4. A TLS certificate (buy + install + renew)
+5. Hope your ISP doesn't block port 80/443 (many do)
+
+Cloudflare Tunnel eliminates ALL of that. How? By reversing the connection direction.
+
+### The Core Idea
+
+Instead of traffic flowing IN to your laptop, your laptop reaches OUT to Cloudflare:
+
+```
+Traditional (INBOUND):              Cloudflare Tunnel (OUTBOUND):
+
+User ──→ your public IP ──→         User ──→ Cloudflare edge ──→ your laptop
+        your laptop                          (outbound connection
+        (router forwards                     initiated by laptop)
+         port 443)
+```
+
+### Analogy 1: Phone Call vs Walkie-Talkie
+
+**Traditional = Phone call.** Someone needs your number (public IP). Your number must
+be listed (DNS). Your phone must ring (open port). If you change numbers or your
+carrier blocks the call, nobody reaches you.
+
+**Cloudflare Tunnel = Walkie-talkie.** You and Cloudflare tune to the same channel.
+You press the button and say "I'm here." Cloudflare now knows how to reach you.
+Users talk to Cloudflare, Cloudflare relays to you through the already-open channel.
+No phone number. No port forwarding. You initiated the call, so your router allows
+it — just like browsing the web.
+
+### Analogy 2: Hotel Front Desk
+
+```
+Route53 DNS = a public directory listing room numbers
+Cloudflare DNS = the hotel front desk
+
+Without Cloudflare Tunnel:
+  Visitor checks directory → "Room 104" → walks to room 104 → knocks
+  But room 104 is your laptop behind a router. There's no door to knock on.
+
+With Cloudflare Tunnel:
+  You tell the front desk "I'm in room 104, send my visitors to me"
+  Visitor asks front desk → "parcel-management?" → front desk forwards them
+  The visitor never sees your room number. No door needs to be open.
+```
+
+### How the Connection Works (Moment by Moment)
+
+```
+MOMENT 1 — Tunnel starts:
+┌──────────┐                                    ┌──────────────┐
+│ LAPTOP   │── OUTBOUND connection ────────────▶│  CLOUDFLARE  │
+│cloudflared│   "I'm tunnel abc123. Send me     │    EDGE      │
+│          │    traffic for these domains..."    │              │
+└──────────┘                                    │  Notes:      │
+                                                │  abc123 ↔   │
+                                                │  parcel-     │
+                                                │  management  │
+                                                │  .qawitherev │
+                                                │  .com        │
+                                                └──────────────┘
+
+MOMENT 2 — User visits your site:
+┌──────────┐     ┌──────────────┐     ┌──────────────┐     ┌──────────┐
+│  USER    │────▶│  CLOUDFLARE  │────▶│  CLOUDFLARE  │────▶│ LAPTOP   │
+│browser   │     │    DNS       │     │    EDGE      │     │          │
+│          │     │  parcel-...  │     │              │     │"Someone  │
+│          │     │  → CF IPs    │     │  "I know this│     │ wants    │
+│          │     │  (🟠 proxied)│     │   domain.    │     │ parcel-  │
+│          │     │              │     │   Tunnel     │     │ ...com!" │
+│          │     │              │     │   abc123 is  │     │          │
+│          │     │              │     │   waiting."  │     │          │
+└──────────┘     └──────────────┘     └──────┬───────┘     └──────────┘
+                                             │
+                                    Request goes through
+                                    the already-open
+                                    outbound connection
+```
+
+### What Cloudflare Tunnel Replaces from AWS
+
+| AWS Component | What It Did | Cloudflare Tunnel Replacement |
+|---|---|---|
+| ALB | HTTPS endpoint, routing | Cloudflare edge + nginx on laptop |
+| ACM | TLS certificate | Cloudflare auto-provisioned edge cert |
+| Security Group (443) | Allow inbound traffic | Not needed — zero inbound ports |
+| Public subnet | Where ALB lived | Not needed — laptop is on home LAN |
+| NAT Gateway | Private subnet → internet | Home router (always doing NAT) |
+| Elastic IP | Static public address | Not needed — IP never exposed |
+
+### Common "Aha" Questions
+
+**"So my laptop calls Cloudflare, not the other way around?"**
+Yes. `cloudflared` dials out. Your router sees it as "browsing the web." It has no
+idea the traffic is actually serving a website.
+
+**"Do I need port 80/443 open on my router?"**
+No. Outbound connections are already allowed (that's how you browse the web). The
+tunnel rides on those.
+
+**"What if my ISP changes my public IP?"**
+Doesn't matter. The tunnel reconnects within seconds. Cloudflare always knows where
+your tunnel is because your laptop called Cloudflare.
+
+**"What if my internet goes down?"**
+The tunnel disconnects. Cloudflare shows a 502 page. When internet returns,
+`cloudflared` auto-reconnects. No manual intervention.
+
+**"Does this cost money?"**
+Cloudflare Tunnel is free. No usage limits, no bandwidth charges. The only
+requirement: Cloudflare must be your DNS provider (covered in Phase 9).
+
+**"Can someone find my home IP through this?"**
+No. DNS resolves to Cloudflare's IPs, not yours. The tunnel is outbound. Your IP
+is never in a DNS record.
+
+---
+
+## 10. Phase 7: Cloudflare Tunnel — Setup
+
+### Step 9.1: Authenticate cloudflared
+
+```bash
+# This command opens a browser window on your Windows host
+# You'll log into Cloudflare and authorize the tunnel
+cloudflared tunnel login
+```
+
+What happens:
+1. A browser opens on Windows
+2. Log into your Cloudflare account (create one at cloudflare.com if you haven't)
+3. Select the domain `qawitherev.com` (you must add this domain to Cloudflare first — see Phase 7)
+4. Authorize the tunnel
+
+After authorizing, the credential is saved to `~/.cloudflared/cert.pem`.
+
+**If the browser doesn't open** (or you're SSH'd in), the terminal prints a URL.
+Copy it and open it manually on your Windows machine.
+
+### Step 9.2: Create the Tunnel
+
+```bash
+cloudflared tunnel create parcel-management
+```
+
+Output:
+```
+Tunnel credentials written to /home/qawitherev/.cloudflared/<UUID>.json
+cloudflared chose the name "parcel-management" for this tunnel.
+Created tunnel parcel-management with id <UUID>
+```
+
+Make a note of the tunnel ID (the UUID). You'll need it in the config file.
+
+### Step 9.3: Configure the Tunnel
+
+```bash
+# Create the config directory
+sudo mkdir -p /etc/cloudflared
+
+# Create the config file
+sudo nano /etc/cloudflared/config.yml
+```
+
+Paste this (replace placeholders):
+
+```yaml
+# ────────────────────────────────────────────
+# Cloudflare Tunnel Configuration
+# ────────────────────────────────────────────
+
+# Tunnel ID from the "cloudflared tunnel create" output
+tunnel: <YOUR-TUNNEL-UUID>
+
+# Path to the credentials file cloudflared created
+credentials-file: /home/qawitherev/.cloudflared/<YOUR-TUNNEL-UUID>.json
+# ⚠️  Replace <YOUR-TUNNEL-UUID> with the actual UUID
+# ⚠️  Replace /home/qawitherev/ with your actual Linux username
+
+# ─── Ingress Rules ──────────────────────────
+# These define how traffic is routed.
+# Think of them like ALB listener rules (hostname → target group).
+# Cloudflare evaluates rules top-to-bottom, first match wins.
+#
+# ⚠️  Frontend hostnames (parcel-management.qawitherev.com,
+# staging.parcel-management.qawitherev.com) stay on CloudFront/S3.
+# Only API hostnames route through the tunnel.
+
+ingress:
+  # Production API
+  - hostname: api-parcel-management.qawitherev.com
+    service: http://localhost:8080
+
+  # Staging API
+  - hostname: api-staging-parcel-management.qawitherev.com
+    service: http://localhost:8081
+
+  # Catch-all: reject anything that doesn't match a hostname
+  - service: http_status:404
+```
+
+**Important:** nginx on the laptop is a pure API reverse proxy. It proxies all
+requests to the .NET backend — no static file serving. The frontend is served from
+S3 + CloudFront, completely separate from this tunnel.
+
+### Step 9.4: Route DNS Records
+
+This tells Cloudflare: "when someone looks up `parcel-management.qawitherev.com`, send
+their traffic through this tunnel."
+
+```bash
+cloudflared tunnel route dns parcel-management api-parcel-management.qawitherev.com
+cloudflared tunnel route dns parcel-management api-staging-parcel-management.qawitherev.com
+```
+
+Each command creates a CNAME record in Cloudflare DNS pointing `<hostname>` → `<tunnel-id>.cfargotunnel.com`.
+
+> Frontend hostnames (`parcel-management.qawitherev.com`, `staging.parcel-management.qawitherev.com`)
+> stay on CloudFront — their DNS records remain unchanged in Route53 until the full DNS
+> migration in Phase 9.
+
+**Verify in Cloudflare dashboard:** Go to DNS → Records. You should see two CNAME records
+with orange cloud icons (proxied).
+
+### Step 9.5: Install Tailscale for SSH Access
+
+SSH access to the laptop uses [Tailscale](https://tailscale.com/) — a WireGuard-based
+mesh VPN that gives every device a stable private IP and MagicDNS hostname. This is
+simpler and more reliable than routing SSH through Cloudflare Tunnel.
+
+#### Why Tailscale Instead of Cloudflare Tunnel for SSH
+
+Cloudflare Tunnel is designed for HTTP traffic. While it supports arbitrary TCP
+(including SSH on port 22), the setup requires additional ingress rules and doesn't
+add meaningful value over Tailscale. With Tailscale:
+
+- Every device gets a stable private IP (e.g., `100.93.150.118`) — no DNS dependencies
+- MagicDNS lets you use hostnames like `qawi-rog` instead of IPs
+- SSH works out of the box — just `ssh user@100.93.150.118`
+- The connection is end-to-end encrypted via WireGuard
+- Free for up to 100 devices
+
+#### Installation
+
+```bash
+# Install Tailscale in WSL2
+curl -fsSL https://tailscale.com/install.sh | sh
+
+# Start Tailscale and authenticate
+sudo tailscale up
+
+# This prints a URL — open it in a browser to authenticate
+# After auth, your machine joins your tailnet
+```
+
+Verify connectivity from your Mac (install Tailscale on the Mac too):
+
+```bash
+# From your Mac terminal:
+tailscale status
+# Should show your Mac and the WSL2 machine (qawi-rog)
+
+# SSH via Tailscale IP:
+ssh qawitherev@100.93.150.118
+```
+
+#### SSH Key Setup
+
+For passwordless SSH (required for CI/CD deployments), add your Mac's public key
+to the WSL2 machine's authorized keys:
+
+```bash
+# On your Mac:
+cat ~/.ssh/id_ed25519.pub | ssh qawitherev@100.93.150.118 "cat >> ~/.ssh/authorized_keys"
+```
+
+Or from the WSL2 side:
+```bash
+# On the WSL2 machine:
+cat ~/.ssh/id_ed25519.pub >> ~/.ssh/authorized_keys
+chmod 600 ~/.ssh/authorized_keys
+```
+
+### Step 9.6: Install cloudflared as a systemd Service
+
+```bash
+# cloudflared has a built-in command to install itself as a service
+sudo cloudflared service install
+
+# Enable and start it
+sudo systemctl enable cloudflared
+sudo systemctl start cloudflared
+
+# Check status
+sudo systemctl status cloudflared
+# Should show: Active: active (running)
+```
+
+This creates `/etc/systemd/system/cloudflared.service` automatically and starts the tunnel.
+
+### Step 9.7: Test the Full Internet-to-Laptop Flow
+
+```bash
+# Test from inside WSL2 using curl with the Host header (simulates browser request)
+curl -H "Host: api-parcel-management.qawitherev.com" http://localhost:8080/health
+# Should return: Healthy
+
+# Now test from your PHONE (turn off WiFi, use cellular data):
+# Open browser → https://api-parcel-management.qawitherev.com/health
+# Should return: Healthy
+```
+
+**⚠️ Important:** DNS propagation can take a few minutes. If it doesn't work immediately,
+wait 5 minutes and try again. Check Cloudflare DNS dashboard to confirm the CNAME records exist.
+
+### Step 9.8: Understand Cloudflare Tunnel Commands
+
+```bash
+# View all your tunnels
+cloudflared tunnel list
+
+# View detailed info for a tunnel
+cloudflared tunnel info parcel-management
+
+# Delete a tunnel (if you need to recreate)
+cloudflared tunnel delete parcel-management
+
+# View tunnel logs
+sudo journalctl -u cloudflared -f
+
+# Test the config without running the service
+cloudflared tunnel ingress validate
+```
+
+---
+
+## 11. Phase 8: TLS Termination
+
+**Goal:** Understand where encryption ends in the new setup and why.
+
+### What "TLS Termination" Means
+
+TLS (the padlock in your browser) encrypts traffic between two points. "Termination"
+is the point where encryption is **decrypted** — where the lock is opened and the
+request becomes plain HTTP.
+
+Every HTTPS request goes through at least one termination point. The question is: where?
+
+### Your Current AWS Setup (One Termination)
+
+```
+Browser                    ALB                     ECS (Fargate)
+   │                         │                         │
+   │── HTTPS ───────────────→│                         │
+   │  (encrypted)            │  TLS TERMINATED HERE    │
+   │                         │                         │
+   │                         │── HTTP ────────────────→│
+   │                         │  (plain, inside VPC)    │
+```
+
+1. Browser encrypts with the ACM certificate on the ALB
+2. ALB decrypts (termination point)
+3. ALB forwards as plain HTTP over the private VPC
+4. Inside the VPC is trusted — no encryption between ALB and ECS
+
+### Your New Setup (Two Terminations)
+
+```
+Browser          Cloudflare Edge          cloudflared          nginx           .NET API
+   │                   │                       │                  │                │
+   │── HTTPS ─────────→│                       │                  │                │
+   │  (encrypted)      │  TLS TERMINATED #1    │                  │                │
+   │                   │                       │                  │                │
+   │                   │── QUIC/HTTP2 ────────→│                  │                │
+   │                   │  (encrypted tunnel)   │  TERMINATED #2   │                │
+   │                   │                       │                  │                │
+   │                   │                       │── HTTP ─────────→│                │
+   │                   │                       │  (plain,         │── HTTP ───────→│
+   │                   │                       │   localhost)     │  (plain)       │
+```
+
+**TLS Termination #1 — Cloudflare Edge:**
+The browser's HTTPS ends at Cloudflare. Cloudflare has a free **edge certificate**
+for your domain, auto-provisioned, auto-renewed. Request is decrypted here.
+
+**TLS Termination #2 — cloudflared on your laptop:**
+Cloudflare re-encrypts and sends through the tunnel (QUIC/HTTP2). `cloudflared`
+decrypts it when it arrives. This second encryption is necessary because the
+tunnel crosses the public internet between Cloudflare and your home router.
+
+**Plain HTTP on localhost:**
+From `cloudflared` → nginx → .NET, traffic is plain HTTP over `127.0.0.1`.
+This is safe because localhost traffic never leaves the machine — it's all
+in-memory. If an attacker can sniff your localhost, they already own the laptop.
+
+### Why Not Terminate TLS on the Laptop Instead?
+
+You could. There are three options:
+
+**Option A — TLS terminated at Cloudflare (what this plan uses):**
+```
+User ──HTTPS──▶ CF Edge ──Tunnel──▶ cloudflared ──HTTP──▶ nginx ──HTTP──▶ .NET
+```
+Cloudflare decrypts. Tunnel encrypts. cloudflared decrypts. Plain to nginx.
+
+**Option B — TLS terminated at nginx on the laptop:**
+```
+User ──HTTPS──────────────────────────────────────────▶ nginx ──HTTP──▶ .NET
+```
+The HTTPS blob travels untouched through CF and the tunnel. nginx does the
+termination with your own certificate. Cloudflare never sees plaintext.
+
+**Option C — TLS terminated at .NET Kestrel:**
+```
+User ──HTTPS───────────────────────────────────────────────────────▶ .NET
+```
+No nginx. No CF decryption. .NET's web server terminates TLS directly.
+
+### Comparison
+
+| | Option A (CF Edge) | Option B (nginx) | Option C (.NET) |
+|---|---|---|---|
+| Cloudflare can read traffic | Yes | No | No |
+| Cloudflare CDN caches static files | Yes | No | No |
+| Cloudflare WAF works | Yes | No | No |
+| Certificate management | None (auto) | You (Let's Encrypt) | You (Let's Encrypt) |
+| CPU load on laptop | Minimal | TLS handshakes | TLS handshakes |
+| Complexity | Minimal | Medium | High |
+
+### Why This Plan Uses Option A
+
+For a parcel management backend on old hardware, Option A is the pragmatic choice:
+
+1. **CDN caching is already handled.** The frontend stays on CloudFront/S3 — static
+   assets are cached and served from AWS edge locations. The laptop only handles API
+   requests, which are dynamic and mostly uncacheable anyway.
+
+2. **Zero certificate work.** No certbot, no Let's Encrypt cron jobs, no renewal
+   panics. Cloudflare handles it all.
+
+3. **Cloudflare WAF.** Basic protection against common web attacks without any
+   configuration on your side.
+
+4. **Cloudflare is trusted.** Millions of sites handle far more sensitive data
+   (healthcare, finance) through Cloudflare.
+
+If you later decide you want Option B (end-to-end encryption), the change is
+one line in `config.yml` (`http://` → `https://`) plus a Let's Encrypt cert on
+nginx. The rest of the setup stays the same.
+
+---
+
+## 12. Phase 9: DNS Migration
+
+**Goal:** Move `qawitherev.com` DNS from AWS Route53 to Cloudflare.
+
+### Why Cloudflare Must Be Your DNS Provider
+
+Cloudflare Tunnel only works when Cloudflare manages your DNS. Here's why:
+
+When `cloudflared tunnel route dns` creates a CNAME record like:
+```
+api-parcel-management.qawitherev.com → abc123.cfargotunnel.com
+```
+
+That `cfargotunnel.com` target is a **Cloudflare-internal** record. It only
+resolves when Cloudflare's nameservers are authoritative for your domain.
+Cloudflare needs to be the phonebook to know which tunnel belongs to which domain.
+
+```
+IF Cloudflare has DNS (works):
+  User → DNS lookup → Cloudflare answers → Cloudflare IP
+  User connects → Cloudflare sees domain in its proxy table
+  Cloudflare says "this belongs to tunnel abc123"
+  Cloudflare forwards through the tunnel
+  ✅ Works
+
+IF Route53 has DNS (doesn't work):
+  User → DNS lookup → Route53 answers → you'd need to point at CF IPs
+  But even if you did, traffic arrives at Cloudflare without context
+  Cloudflare says "this domain isn't in my system. I don't proxy it."
+  502 error
+  ❌ Doesn't work
+```
+
+The orange cloud (🟠 proxied) in Cloudflare's DNS dashboard is what wires your
+domain to your tunnel. Without Cloudflare as the authoritative DNS, there's no
+orange cloud, no association, no routing.
+
+### Split Proxy Mode: Grey Cloud for Frontend, Orange Cloud for API
+
+Since the frontend stays on CloudFront while the API moves to the tunnel, you need
+**different proxy modes** for different records:
+
+```
+Cloudflare DNS Records (all under qawitherev.com)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  parcel-management.qawitherev.com
+  └─ CNAME → d123.cloudfront.net       🟢 GREY cloud (DNS-only)
+                                        Cloudflare resolves the name, then
+                                        gets out of the way. Traffic flows
+                                        directly from user → CloudFront → S3.
+
+  api-parcel-management.qawitherev.com
+  └─ CNAME → abc123.cfargotunnel.com   🟠 ORANGE cloud (proxied)
+                                        Cloudflare intercepts traffic and
+                                        routes it through the tunnel to the
+                                        laptop. This is required for the
+                                        tunnel to work.
+
+  staging.parcel-management.qawitherev.com
+  └─ CNAME → d456.cloudfront.net       🟢 GREY cloud (DNS-only)
+
+  api-staging-parcel-management.qawitherev.com
+  └─ CNAME → abc123.cfargotunnel.com   🟠 ORANGE cloud (proxied)
+```
+
+**Why grey cloud for the frontend records?**
+
+If you used orange cloud (proxied) for CloudFront, Cloudflare would sit in front of
+CloudFront — a double CDN. This causes:
+- Extra latency (user → Cloudflare → CloudFront → S3 instead of user → CloudFront → S3)
+- CloudFront loses visibility into client IPs and headers
+- CloudFront's geographic routing and edge features are bypassed
+
+Grey cloud means DNS-only mode: Cloudflare resolves the name to CloudFront's IP and
+steps aside. The traffic path for frontend remains identical to what you have today.
+
+**Why orange cloud for the API records?**
+
+The `cfargotunnel.com` target only resolves inside Cloudflare's network. The orange
+cloud is what associates the hostname with your tunnel. Without it, the tunnel doesn't
+receive the traffic. This is non-negotiable.
+
+### Understanding the Migration
+
+Right now:
+```
+Registrar → Route53 nameservers → qawitherev.com DNS records
+```
+
+After migration:
+```
+Registrar → Cloudflare nameservers → qawitherev.com DNS records
+```
+
+The registrar doesn't change. The nameserver pointer at the registrar is the
+**only thing** that changes. This is like changing your domain's phone book
+from Route53 to Cloudflare. Nobody visiting your site will notice the transition
+if you replicate all records first.
+
+### Step 11.1: Add Your Domain to Cloudflare
+
+1. Go to [Cloudflare Dashboard](https://dash.cloudflare.com)
+2. Click **Add a site** (or **+ Add domain**)
+3. Enter `qawitherev.com`
+4. Select the **Free** plan
+5. Cloudflare scans your existing DNS records from Route53
+6. Review the scanned records — make sure all important ones are there
+7. Cloudflare gives you two nameservers (e.g., `alex.ns.cloudflare.com` and `jill.ns.cloudflare.com`)
+
+### Step 11.2: Update Nameservers at Your Domain Registrar
+
+1. Log into your domain registrar (where you bought `qawitherev.com` — GoDaddy, Namecheap, AWS, etc.)
+2. Find "Nameservers" or "DNS settings"
+3. Replace the existing Route53 nameservers with the two Cloudflare nameservers
+4. Save
+
+**This is the only "scary" step.** DNS change takes 2-48 hours to propagate globally.
+During propagation, some users hit old DNS (Route53), some hit new DNS (Cloudflare).
+Both resolve to the same places if you replicated records correctly. **There is no downtime.**
+
+### Step 11.3: Verify Propagation
+
+```bash
+# Check what nameservers the world sees for your domain
+dig qawitherev.com NS
+# or use: https://www.whatsmydns.net/#NS/qawitherev.com
+
+# Once all locations show Cloudflare nameservers, migration is complete
+```
+
+### Step 11.4: Clean Up Route53
+
+After propagation is confirmed (wait 48 hours to be safe):
+
+```bash
+# Don't delete the hosted zone until you're 100% sure everything works
+# Route53 hosted zones cost $0.50/month — cheap insurance for a month
+
+# When ready:
+# 1. Delete all record sets (except NS and SOA)
+# 2. Delete the hosted zone
+# Or let Terraform manage this (add a `terraform destroy` for the DNS module)
+```
+
+---
+
+## 13. Phase 10: CI/CD Pipeline (Dual-Mode)
+
+**Goal:** Keep the existing AWS pipeline intact. Add a second deployment path for
+the laptop. A single `deployment_target` variable controls which path runs.
+
+### The Dual-Mode Design
+
+```
+Git Push or Manual Trigger
+        │
+        ▼
+┌──────────────────────────────────────────────────┐
+│              GitHub Actions                      │
+│                                                  │
+│  Tests (always run, ubuntu-latest)               │
+│  ┌────────────────────────────────┐              │
+│  │ dotnet test / build verify     │              │
+│  └────────────────────────────────┘              │
+│           │                                      │
+│           ▼                                      │
+│  deployment_target = ?                           │
+│       │           │                              │
+│       ▼           ▼                              │
+│  ┌─────────┐ ┌──────────┐                        │
+│  │   AWS   │ │  LAPTOP  │                        │
+│  │  (ECR   │ │  (cloud  │                        │
+│  │   ECS   │ │  build + │                        │
+│  │   S3)   │ │  SSH via │                        │
+│  │         │ │  tunnel) │                        │
+│  └─────────┘ └──────────┘                        │
+│     ↑             ↑                              │
+│  existing     new path                           │
+│  unchanged    added alongside                    │
+└──────────────────────────────────────────────────┘
+```
+
+**AWS path:** Default. Runs on `git push`. Exactly as it works today — ECR, ECS, S3,
+Terraform. Frontend always deploys via this path. Zero changes.
+
+**Laptop path (backend only):** Manual trigger (`workflow_dispatch`) only. Builds the
+backend on GitHub's cloud runner (fast), packages into a `.tar.gz`, `scp`'s the
+artifact to the laptop via SSH tunnel, runs `deploy.sh` to stop/swap/start/verify.
+Frontend is never deployed to the laptop — it stays on S3 + CloudFront.
+
+### Why Not a Self-Hosted Runner?
+
+The earlier version of this plan recommended installing a GitHub Actions runner on
+the laptop itself. The problem: building on old hardware is slow (2-4 minutes for
+`dotnet publish`). The laptop should only run the app — not compile it.
+
+Instead, builds happen on GitHub's cloud runners (fast, free for public repos),
+and only the final artifact is transferred to the laptop.
+
+### Step 12.1: Create deploy.sh on the Laptop + SSH Setup
+
+This script receives a pre-built `.tar.gz`, extracts it, stops the service, swaps
+files, starts the service, and verifies health. Builds do NOT happen here.
+
+#### SSH Access via Tailscale
+
+SSH access uses Tailscale (set up in Step 9.5). GitHub Actions connects directly
+to the laptop's Tailscale IP — no Cloudflare Tunnel needed for SSH.
+
+Add your Mac's SSH public key to the WSL2 machine (one-time):
+
+```bash
+# On your Mac:
+cat ~/.ssh/id_ed25519.pub | ssh qawitherev@100.93.150.118 "cat >> ~/.ssh/authorized_keys"
+```
+
+For CI/CD, generate a dedicated deploy key:
+
+```bash
+# On the laptop (WSL2)
+ssh-keygen -t ed25519 -f ~/.ssh/github-actions -N "" -C "github-actions-deploy"
+cat ~/.ssh/github-actions.pub >> ~/.ssh/authorized_keys
+chmod 600 ~/.ssh/authorized_keys
+```
+
+Copy the private key to add as a GitHub secret:
+
+```bash
+cat ~/.ssh/github-actions
+# Copy the output. Add as LAPTOP_SSH_PRIVATE_KEY in GitHub repo settings.
+```
+
+#### The Deploy Script
+
+```bash
+nano ~/deploy.sh
+```
+
+```bash
+#!/bin/bash
+# ────────────────────────────────────────────
+# Parcel Management — Backend Deployment Script
+# Receives pre-built artifacts from GitHub Actions
+# Usage: bash deploy.sh
+# ────────────────────────────────────────────
+
+set -e
+set -o pipefail
+
+LOG_FILE="$HOME/deploy.log"
+BACKEND_DIR="/opt/pm/backend"
+BACKEND_TAR="$HOME/backend.tar.gz"
+EXTRACT_DIR="/opt/pm/backend-new"
+SERVICE="pm-api"
+HEALTH_URL="http://127.0.0.1:5163/health"
+
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" | tee -a "$LOG_FILE"
+}
+
+log "=== Backend Deployment ==="
+
+# 1. Extract
+log "Extracting $BACKEND_TAR..."
+rm -rf "$EXTRACT_DIR"
+mkdir -p "$EXTRACT_DIR"
+tar -xzf "$BACKEND_TAR" -C "$EXTRACT_DIR"
+# The tar was created as: tar -czf backend.tar.gz publish/backend/
+# So files are in publish/backend/ inside the extract directory
+if [ -d "$EXTRACT_DIR/publish/backend" ]; then
+    mv "$EXTRACT_DIR/publish/backend/"* "$EXTRACT_DIR/"
+    rm -rf "$EXTRACT_DIR/publish"
+fi
+
+# 2. Stop
+log "Stopping $SERVICE..."
+sudo systemctl stop "$SERVICE"
+
+# 3. Swap
+log "Swapping old → new..."
+rm -rf "$BACKEND_DIR-old"
+mv "$BACKEND_DIR" "$BACKEND_DIR-old" 2>/dev/null || true
+mv "$EXTRACT_DIR" "$BACKEND_DIR"
+sudo chown -R pm-svc:pm-svc "$BACKEND_DIR"
+
+# 4. Start
+log "Starting $SERVICE..."
+sudo systemctl start "$SERVICE"
+sleep 5
+
+# 5. Health check
+if curl -sf "$HEALTH_URL" > /dev/null 2>&1; then
+    log "Health check PASSED"
+    rm -rf "$BACKEND_DIR-old"
+    rm -f "$BACKEND_TAR"
+else
+    log "Health check FAILED — rolling back"
+    sudo systemctl stop "$SERVICE"
+    rm -rf "$BACKEND_DIR"
+    mv "$BACKEND_DIR-old" "$BACKEND_DIR"
+    sudo chown -R pm-svc:pm-svc "$BACKEND_DIR"
+    sudo systemctl start "$SERVICE"
+    log "Rolled back to previous version"
+    exit 1
+fi
+
+log "=== Backend Deployment Complete ==="
+```
+
+```bash
+chmod +x ~/deploy.sh
+
+# Allow passwordless sudo for the commands deploy.sh uses
+sudo visudo -f /etc/sudoers.d/pm-deploy
+```
+
+```
+# Add this line (replace qawitherev with your Linux username):
+qawitherev ALL=(ALL) NOPASSWD: /usr/bin/systemctl, /usr/bin/rm, /usr/bin/mv, /usr/bin/mkdir, /usr/bin/cp, /usr/bin/chown
+```
+
+### Step 12.2: Backend CD Workflow (Dual-Mode)
+
+The workflow for `.github/workflows/cd-backend-staging.yml`:
+
+```yaml
+name: CD - Backend Staging
+
+on:
+  push:
+    branches: [staging]
+    paths: ['backend/**']
+  workflow_dispatch:
+    inputs:
+      deployment_target:
+        description: 'Where to deploy'
+        required: true
+        type: choice
+        default: 'aws'
+        options: [aws, self-hosted]
+
+jobs:
+  test:
+    # Tests always run, regardless of deployment target
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+      - run: dotnet test backend/
+
+  # ─── AWS PATH (default, unchanged from today) ───
+  deploy-aws:
+    needs: test
+    if: ${{ github.event.inputs.deployment_target == 'aws' || github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+      - name: Build and push Docker image
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPO:${{ github.sha }} backend/src/
+          docker push $ECR_REGISTRY/$ECR_REPO:${{ github.sha }}
+      - name: Terraform apply
+        run: |
+          cd terraform/environments/staging
+          terraform init && terraform apply -auto-approve \
+            -var="github_sha=${{ github.sha }}" \
+            -var="enable_compute=true"
+      - name: Smoke test
+        run: curl -f https://api-staging-parcel-management.qawitherev.com/health
+
+  # ─── SELF-HOSTED PATH (manual trigger only) ───
+  deploy-self-hosted:
+    needs: test
+    if: ${{ github.event.inputs.deployment_target == 'self-hosted' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Build
+        run: dotnet publish backend/src/ParcelManagement.Api -c Release -o publish/backend
+
+      - name: Package
+        run: tar -czf backend.tar.gz publish/backend
+
+      - name: Copy artifact to laptop
+        env:
+          SSH_KEY: ${{ secrets.LAPTOP_SSH_PRIVATE_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$SSH_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          scp -o StrictHostKeyChecking=no -i ~/.ssh/deploy_key \
+            backend.tar.gz qawitherev@<TAILSCALE-IP>:/home/qawitherev/
+
+      - name: Deploy
+        run: |
+          ssh -o StrictHostKeyChecking=no -i ~/.ssh/deploy_key \
+            qawitherev@<TAILSCALE-IP> "bash /home/qawitherev/deploy.sh"
+
+      - name: Verify
+        run: curl -f https://api-staging-parcel-management.qawitherev.com/health
+```
+
+### How the SSH Connection Works (Tailscale)
+
+The GitHub runner SSHs to the laptop's Tailscale IP. Here's the path:
+
+```
+GitHub Runner (ubuntu-latest)              Laptop (WSL2)
+   │                                           │
+   │  1. ssh qawitherev@<TAILSCALE-IP>        │
+   │     GitHub Actions has an SSH key          │
+   │     added to the laptop's authorized_keys  │
+   │                                           │
+   │  2. SSH over the public internet          │
+   │     Tailscale wireguard tunnel             │
+   │     encrypts the entire connection         │
+   │                                           │
+   │─────── SSH session ──────────────────────▶│
+   │                                           │
+   │                                           │ 3. Laptop authenticates
+   │                                           │    via the public key in
+   │                                           │    ~/.ssh/authorized_keys
+   │                                           │
+   │◀─────── SSH session established ──────────│
+```
+
+No Cloudflare Tunnel needed for SSH. No DNS dependency. No open ports.
+Tailscale provides a stable private IP that works regardless of whether
+the laptop is behind NAT or on a different network.
+
+> **Note:** GitHub Actions runners can't install Tailscale directly (they're
+> ephemeral). The SSH connection goes over the public internet to the
+> Tailscale IP, secured by the SSH key. If you need full end-to-end
+> WireGuard encryption for CI/CD, use a self-hosted runner with Tailscale
+> installed.
+
+### The GitHub Secret
+
+You need one secret in your GitHub repo: `LAPTOP_SSH_PRIVATE_KEY`.
+
+Go to repo → Settings → Secrets and variables → Actions → New repository secret.
+
+Name: `LAPTOP_SSH_PRIVATE_KEY`
+Value: the content of `~/.ssh/github-actions` from the laptop (the entire file,
+including the `-----BEGIN OPENSSH PRIVATE KEY-----` and `-----END OPENSSH PRIVATE KEY-----` lines).
+
+Also store the Tailscale IP as a variable:
+Name: `TAILSCALE_LAPTOP_IP`
+Value: `100.93.150.118` (or whatever `tailscale status` shows for the WSL2 machine)
+
+### Step 13.3: Frontend Deployment (AWS Only)
+
+The frontend stays on S3 + CloudFront. Its deployment pipeline is **unchanged** —
+`npm run build` → `aws s3 sync` → CloudFront invalidation. There is no laptop
+deployment path for the frontend. The existing frontend CD workflow continues to
+work exactly as it does today.
+
+### Runtime Behavior
+
+```
+Push to staging branch:
+  deploy-aws:           ✅ runs (default)
+  deploy-self-hosted:   ❌ skipped
+
+Manual trigger + select "aws":
+  deploy-aws:           ✅ runs
+  deploy-self-hosted:   ❌ skipped
+
+Manual trigger + select "self-hosted":
+  deploy-aws:           ❌ skipped
+  deploy-self-hosted:   ✅ runs
+
+Result: One trigger, one build, one deployment target.
+        No duplicate work. No confusion.
+```
+
+### Production Environment
+
+The same dual-mode pattern applies to production workflows. The only differences:
+- Branch: `main` instead of `staging`
+- Environment URLs: `parcel-management.qawitherev.com` instead of `staging.parcel-management.qawitherev.com`
+- Trigger: `workflow_dispatch` only (manual) for both AWS and self-hosted modes — no automatic push trigger for production
+
+### Troubleshooting Deployments
+
+If the self-hosted deploy fails:
+
+1. **Check GitHub Actions log** for the failed step
+2. **Test SSH from your Mac via Tailscale:**
+   ```bash
+   ssh qawitherev@100.93.150.118 "echo ok"
+   ```
+   If this works, SSH is fine and the issue is in the deploy script.
+3. **Is the persistent tunnel up?**
+   ```bash
+   # On the laptop
+   sudo systemctl status cloudflared
+   ```
+4. **Is the SSH server running?**
+   ```bash
+   sudo systemctl status ssh
+   ```
+5. **Is the SSH key in `authorized_keys`?**
+   ```bash
+   cat ~/.ssh/authorized_keys
+   # Should show the Mac's public key and the github-actions public key
+   ```
+6. **Check Tailscale connectivity:**
+   ```bash
+   tailscale status
+   # Should show qawi-rog as connected
+   ```
+7. **Check deploy log on laptop:**
+   ```bash
+   cat ~/deploy.log
+   ```
+8. **Check service logs:**
+   ```bash
+   sudo journalctl -u pm-api -n 50
+   ```
+
+---
+
+## 14. Phase 11: Staging Environment
+
+**Goal:** Run staging and production side-by-side on the same laptop.
+
+The approach: staging runs on **different ports**.
+
+| Environment | nginx port | Backend port | API Domain |
+|---|---|---|---|
+| Production | 8080 | 5163 | `api-parcel-management.qawitherev.com` |
+| Staging | 8081 | 5164 | `api-staging-parcel-management.qawitherev.com` |
+
+> Frontend domains (`parcel-management.qawitherev.com`, `staging.parcel-management.qawitherev.com`)
+> stay on CloudFront/S3 and are unchanged.
+
+### Step 13.1: Create Staging Backend Service
+
+```bash
+# Create the staging .env file (different DB, different secrets)
+sudo cp /etc/parcel-management/.env /etc/parcel-management/.env.staging
+sudo nano /etc/parcel-management/.env.staging
+# Change ASPNETCORE_URLS=http://127.0.0.1:5164
+# Change ASPNETCORE_ENVIRONMENT=Staging
+# Update AllowedOrigins to include staging domain
+
+# Create staging directory
+sudo mkdir -p /opt/pm/staging-backend
+
+# Build staging backend
+cd ~/parcel-management-system/backend/src
+dotnet publish ParcelManagement.Api -c Release -o ~/pm/staging-backend
+sudo mv ~/pm/staging-backend /opt/pm/staging-backend
+sudo chown -R pm-svc:pm-svc /opt/pm/staging-backend
+```
+
+Create the staging systemd service:
+
+```bash
+sudo nano /etc/systemd/system/pm-api-staging.service
+```
+
+```ini
+[Unit]
+Description=Parcel Management API — Staging
+After=network.target
+
+[Service]
+Type=simple
+User=pm-svc
+Group=pm-svc
+WorkingDirectory=/opt/pm/staging-backend
+EnvironmentFile=/etc/parcel-management/.env.staging
+ExecStart=/usr/bin/dotnet /opt/pm/staging-backend/ParcelManagement.Api.dll
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=pm-api-staging
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+ReadWritePaths=/opt/pm/staging-backend /tmp
+PrivateTmp=yes
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now pm-api-staging
+```
+
+### Step 14.2: Create Staging nginx Config
+
+```bash
+sudo nano /etc/nginx/sites-available/parcel-management-staging
+```
+
+This is nearly identical to the production nginx config, just different ports:
+
+```nginx
+limit_req_zone $binary_remote_addr zone=api_staging:10m rate=10r/s;
+
+server {
+    listen 8081;
+    server_name _;
+
+    gzip on;
+    gzip_types application/json;
+
+    add_header X-Frame-Options "DENY" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+    location / {
+        limit_req zone=api_staging burst=10 nodelay;
+        proxy_pass http://127.0.0.1:5164;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection keep-alive;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $http_x_forwarded_for;
+        proxy_set_header X-Forwarded-For $http_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 60s;
+    }
+}
+```
+
+```bash
+sudo ln -s /etc/nginx/sites-available/parcel-management-staging /etc/nginx/sites-enabled/
+sudo nginx -t && sudo systemctl reload nginx
+```
+
+### Step 14.3: Verify Both Environments
+
+```bash
+# Production
+curl http://127.0.0.1:8080/health    # → Healthy (port 5163)
+
+# Staging
+curl http://127.0.0.1:8081/health    # → Healthy (port 5164)
+```
+
+The Cloudflare Tunnel config already routes both API domains (see Phase 7 ingress rules):
+- `api-parcel-management.qawitherev.com` → port 8080 (production)
+- `api-staging-parcel-management.qawitherev.com` → port 8081 (staging)
+
+### Step 14.4: Update the Deploy Script for Staging
+
+Add a parameter to the deploy script to handle staging:
+
+```bash
+# In ~/deploy.sh, add near the top:
+ENVIRONMENT="${1:-production}"
+
+if [ "$ENVIRONMENT" = "staging" ]; then
+    BACKEND_DIR="/opt/pm/staging-backend"
+    SERVICE="pm-api-staging"
+    HEALTH_URL="http://127.0.0.1:5164/health"
+else
+    BACKEND_DIR="/opt/pm/backend"
+    SERVICE="pm-api"
+    HEALTH_URL="http://127.0.0.1:5163/health"
+fi
+```
+
+---
+
+## 15. Phase 12: Monitoring & Alerts
+
+**Goal:** Know when your app is down before your users do.
+
+### Step 14.1: Install Uptime Kuma
+
+Uptime Kuma is a self-hosted monitoring tool (like a simple CloudWatch Synthetics).
+It runs as a separate systemd service on the same laptop.
+
+```bash
+# Install Node.js 20.x (needed for Uptime Kuma)
+curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+sudo apt install -y nodejs
+
+# Install Uptime Kuma
+cd /opt
+sudo git clone https://github.com/louislam/uptime-kuma.git
+cd uptime-kuma
+sudo npm run setup
+
+# Create systemd service
+sudo nano /etc/systemd/system/uptime-kuma.service
+```
+
+```ini
+[Unit]
+Description=Uptime Kuma
+After=network.target
+
+[Service]
+Type=simple
+User=pm-svc
+WorkingDirectory=/opt/uptime-kuma
+ExecStart=/usr/bin/node server/server.js
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now uptime-kuma
+```
+
+Access Uptime Kuma at `http://localhost:3001`. Set up monitors:
+
+| Monitor Name | URL | Type | Interval |
+|---|---|---|---|
+| Production API (direct) | `http://127.0.0.1:5163/health` | HTTP(s) | 60s |
+| Production API (via nginx) | `http://127.0.0.1:8080/health` | HTTP(s) | 60s |
+| Staging API (direct) | `http://127.0.0.1:5164/health` | HTTP(s) | 120s |
+| Staging API (via nginx) | `http://127.0.0.1:8081/health` | HTTP(s) | 120s |
+
+Configure Discord or Telegram notifications for when monitors go down.
+
+### Step 14.2: Key systemd Commands for Daily Checks
+
+```bash
+# Is everything running?
+sudo systemctl status pm-api pm-api-staging nginx cloudflared uptime-kuma
+
+# Any errors in the last hour?
+sudo journalctl -u pm-api --since "1 hour ago" -p err
+
+# How much disk space is left?
+df -h /
+
+# How much RAM is being used?
+free -h
+
+# CPU load (should be < 2.0 on a dual-core)
+uptime
+```
+
+### Step 14.3: Set Up Log Rotation
+
+Logs grow over time. Without rotation, they'll fill your disk.
+
+```bash
+sudo nano /etc/systemd/journald.conf
+```
+
+```ini
+[Journal]
+SystemMaxUse=500M
+SystemMaxFileSize=100M
+MaxRetentionSec=14day
+```
+
+```bash
+sudo systemctl restart systemd-journald
+```
+
+---
+
+## 16. Phase 13: Maintenance & Day-2 Operations
+
+### Daily
+
+```bash
+# Quick health check (create an alias for this)
+alias pm-status='sudo systemctl status pm-api pm-api-staging nginx cloudflared'
+pm-status
+```
+
+### Weekly
+
+```bash
+# Update system packages
+sudo apt update && sudo apt upgrade -y
+
+# Check disk usage
+df -h
+
+# Check for failed logins (security)
+sudo journalctl -u ssh --since "1 week ago" | grep -i "failed"
+```
+
+### Monthly
+
+```bash
+# Clean old logs
+sudo journalctl --vacuum-time=30d
+
+# Check for .NET runtime updates
+dotnet --version
+# Compare with latest at https://dotnet.microsoft.com/en-us/download
+
+# Restart the laptop (Windows updates)
+# WSL2 restarts automatically on boot
+```
+
+### When Things Go Wrong
+
+```bash
+# 1. Check what's not running
+sudo systemctl list-units --state=failed
+
+# 2. Check the failing service's logs
+sudo journalctl -u pm-api -n 100 --no-pager
+
+# 3. Restart the service
+sudo systemctl restart pm-api
+
+# 4. If all else fails, restart WSL2
+# From PowerShell: wsl --shutdown
+# Then reopen Ubuntu from Start menu
+
+# 5. If even that fails, reboot Windows
+```
+
+---
+
+## 17. Troubleshooting Guide
+
+### Backend won't start
+
+**Symptom:** `sudo systemctl status pm-api` shows `failed` or `inactive`.
+
+```bash
+# Check the full error
+sudo journalctl -u pm-api -n 50 --no-pager
+
+# Common causes:
+# 1. Missing environment variable → check /etc/parcel-management/.env
+# 2. Wrong .dll path → verify ExecStart path in .service file
+# 3. Port already in use → lsof -i :5163
+# 4. Permissions issue → ls -la /opt/pm/backend/ (should be owned by pm-svc)
+```
+
+**Symptom:** `Active: active (exited)` — the process started but exited immediately.
+
+This usually means an unhandled exception (database connection failed, missing config).
+Check `sudo journalctl -u pm-api -n 50` for the stack trace.
+
+### nginx returns 502 Bad Gateway
+
+**Symptom:** `curl http://127.0.0.1:8080/api/health` returns 502.
+
+This means nginx can't reach the backend. Check:
+1. Is the backend running? `sudo systemctl status pm-api`
+2. Is the backend listening on the right port? `curl http://127.0.0.1:5163/health`
+3. Are the ports correct in the nginx config? `proxy_pass http://127.0.0.1:5163;`
+
+### Cloudflare Tunnel returns 502 or 503
+
+**Symptom:** Browser shows `502 Bad Gateway` from Cloudflare.
+
+1. Is cloudflared running? `sudo systemctl status cloudflared`
+2. Is nginx running? `sudo systemctl status nginx`
+3. Does localhost routing work? `curl -H "Host: parcel-management.qawitherev.com" http://localhost:8080/health`
+4. Check tunnel logs: `sudo journalctl -u cloudflared -n 50`
+
+### DNS not resolving
+
+**Symptom:** Browser shows `DNS_PROBE_FINISHED_NXDOMAIN`.
+
+1. Check Cloudflare DNS dashboard — do the CNAME records exist?
+2. Did you run `cloudflared tunnel route dns` for both API hostnames?
+3. Did nameserver propagation complete? https://www.whatsmydns.net/
+4. Double-check: CNAME target should be `<tunnel-uuid>.cfargotunnel.com`
+
+### Domain resolves but returns 502/000 (router DNS cache)
+
+**Symptom:** `dig` shows the domain resolves correctly at Cloudflare (`1.1.1.1`) but
+your local machine can't connect. The domain works from your phone on cellular data.
+
+**Root cause:** Your home router (`192.168.100.1` or similar) caches DNS responses.
+After switching nameservers from Route53 to Cloudflare, the router may serve stale
+data for hours or days.
+
+**Check:**
+```bash
+# What does your Mac see?
+dig +short qawitherev.com NS
+
+# What does Cloudflare's resolver see?
+dig +short qawitherev.com NS @1.1.1.1
+
+# If they differ, your router has stale cache.
+```
+
+**Fix — Use Cloudflare DNS directly (recommended):**
+Set your Mac to bypass the router's DNS:
+
+1. **System Settings → Wi-Fi → Details → DNS**
+2. Remove the router's IP (e.g., `192.168.100.1`)
+3. Add: `1.1.1.1` and `1.0.0.1` (Cloudflare DNS)
+
+No reboot needed. Your router still handles everything else (NAT, routing, DHCP).
+Only DNS queries go directly to Cloudflare — which is the authoritative nameserver
+for your domain anyway.
+
+**Alternative — Flush macOS DNS cache:**
+```bash
+sudo dscacheutil -flushcache && sudo killall -HUP mDNSResponder
+```
+This only helps if the Mac itself is caching stale data, not the router.
+
+### API works with `--resolve` but not in browser
+
+**Symptom:** `curl --resolve` bypassing DNS works, but browser doesn't.
+
+This is the same router DNS cache issue. Apply the Cloudflare DNS fix above.
+
+### WSL2 won't start
+
+**Symptom:** `wsl` command hangs or shows errors.
+
+```powershell
+# From PowerShell as admin:
+wsl --shutdown
+wsl --update
+wsl --version
+
+# If still broken:
+# Check Windows Features → "Virtual Machine Platform" and "Windows Subsystem for Linux" are enabled
+```
+
+### Build too slow on laptop
+
+If `dotnet publish` takes more than 5 minutes:
+
+1. Switch to **pre-built artifacts:** build in GitHub Actions cloud runners, download the `.tar.gz` artifact on the laptop
+2. Or: only build what changed (incremental builds with `dotnet build` instead of `dotnet publish`)
+
+### Power outage recovery
+
+When power returns:
+1. Laptop should auto-boot (set in BIOS: "Power on when AC is restored")
+2. Windows auto-starts the GitHub Actions Runner service
+3. WSL2 auto-starts when you open a terminal (or set a scheduled task to run `wsl --exec systemctl is-active pm-api` at boot)
+4. systemd auto-starts pm-api, nginx, and cloudflared (because they're all `enabled`)
+
+To make WSL2 auto-start on boot without opening a terminal, create a scheduled task in Windows:
+
+```powershell
+# In PowerShell as Administrator
+$action = New-ScheduledTaskAction -Execute "wsl.exe" -Argument "--exec sudo systemctl is-active pm-api"
+$trigger = New-ScheduledTaskTrigger -AtStartup
+Register-ScheduledTask -TaskName "WSL2 Auto Start" -Action $action -Trigger $trigger -RunLevel Highest
+```
+
+---
+
+## 18. Full File Reference
+
+Every file you created, in one place for reference:
+
+| File | Purpose | Owner |
+|---|---|---|
+| `%USERPROFILE%\.wslconfig` | WSL2 memory/CPU limits | Windows |
+| `/etc/parcel-management/.env` | Production environment variables | root:root (600) |
+| `/etc/parcel-management/.env.staging` | Staging environment variables | root:root (600) |
+| `/etc/nginx/sites-available/parcel-management` | Production nginx config (API proxy) | root |
+| `/etc/nginx/sites-available/parcel-management-staging` | Staging nginx config (API proxy) | root |
+| `/etc/systemd/system/pm-api.service` | Production backend service | root |
+| `/etc/systemd/system/pm-api-staging.service` | Staging backend service | root |
+| `/etc/systemd/system/uptime-kuma.service` | Monitoring service | root |
+| `/etc/cloudflared/config.yml` | Cloudflare Tunnel config | root |
+| `~/.cloudflared/<uuid>.json` | Tunnel credentials | user |
+| `~/deploy.sh` | Backend deployment script | user |
+| `/opt/pm/backend/` | Production backend binaries | pm-svc |
+| `/opt/pm/staging-backend/` | Staging backend binaries | pm-svc |
+
+> Frontend files stay in S3. Nothing frontend-related exists on the laptop.
+
+### Quick Start After Reboot
+
+The laptop was rebooted. What needs to happen?
+
+1. **Windows boots** → GitHub Actions Runner service auto-starts
+2. **WSL2 boots** (when triggered by scheduled task or first terminal open) →
+   - systemd auto-starts: `pm-api`, `pm-api-staging`, `nginx`, `cloudflared`, `uptime-kuma`
+3. **cloudflared connects to Cloudflare** → tunnel is established
+4. **Everything is online** within ~30 seconds of WSL2 starting
+
+Verify with:
+```bash
+sudo systemctl status pm-api pm-api-staging nginx cloudflared uptime-kuma
+```
+
+---
+
+## Cost Summary
+
+| Item | Before (AWS) | After (Hybrid) |
+|---|---|---|
+| ECS Fargate (2 envs) | ~$14.60/mo | $0 |
+| ALB (2 envs) | ~$40.00/mo | $0 |
+| NAT Gateways (2 envs) | ~$68.00/mo | $0 |
+| S3 + CloudFront | ~$2.00/mo | ~$2.00/mo (unchanged — frontend stays) |
+| Route53 Hosted Zones | ~$1.00/mo | $0 |
+| Cloudflare | — | Free |
+| Electricity (~30W 24/7) | — | ~$2.50/mo |
+| **Total** | **~$126/mo** | **~$4.50/mo** |
+
+Annual: ~$1,460 saved. The laptop pays for itself in under 2 months (if you consider
+it a sunk cost since you already own it).
+
+---
+
+## Next Steps After Implementation
+
+1. Run in parallel with AWS for 1 week (keep `enable_compute = true` temporarily)
+2. Switch API DNS to Cloudflare Tunnel
+3. Monitor for 48 hours (check Uptime Kuma, Cloudflare Analytics)
+4. If stable: set `enable_compute = true` and only destroy ECS + ALB resources (keep S3 + CloudFront)
+5. Export SSM parameters one final time, then destroy SSM Terraform resources
+
+> S3 + CloudFront stay permanently — the frontend continues to be served from AWS.

--- a/brainboard.tf
+++ b/brainboard.tf
@@ -1,0 +1,381 @@
+# ============================================================
+# Brainboard — Parcel Management System Architecture
+# ============================================================
+# Only core infrastructure for a clean diagram.
+# Not for apply.
+# ============================================================
+
+terraform {
+  required_providers {
+    aws = { source = "hashicorp/aws" }
+  }
+}
+
+provider "aws" {
+  region = "ap-southeast-1"
+}
+
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+}
+
+# ============================================================
+# VPC + NETWORKING
+# ============================================================
+
+resource "aws_vpc" "main" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = { Name = "parcel-management-production" }
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+  tags   = { Name = "parcel-management-production" }
+}
+
+resource "aws_eip" "nat" {
+  domain = "vpc"
+}
+
+resource "aws_nat_gateway" "main" {
+  allocation_id = aws_eip.nat.id
+  subnet_id     = aws_subnet.public[0].id
+
+  depends_on = [aws_internet_gateway.main]
+  tags       = { Name = "parcel-management-production" }
+}
+
+resource "aws_subnet" "public" {
+  count                   = 2
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = ["10.0.1.0/24", "10.0.2.0/24"][count.index]
+  availability_zone       = ["ap-southeast-1a", "ap-southeast-1b"][count.index]
+  map_public_ip_on_launch = true
+
+  tags = { Name = "public-${count.index + 1}" }
+}
+
+resource "aws_subnet" "private" {
+  count             = 2
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = ["10.0.3.0/24", "10.0.4.0/24"][count.index]
+  availability_zone = ["ap-southeast-1a", "ap-southeast-1b"][count.index]
+
+  tags = { Name = "private-${count.index + 1}" }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  count          = 2
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.main.id
+  }
+}
+
+resource "aws_route_table_association" "private" {
+  count          = 2
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private.id
+}
+
+# ============================================================
+# ACM CERTIFICATES (SSL)
+# ============================================================
+
+resource "aws_acm_certificate" "alb" {
+  domain_name               = "parcel-management.qawitherev.com"
+  subject_alternative_names = ["api-parcel-management.qawitherev.com"]
+  validation_method         = "DNS"
+
+  lifecycle { create_before_destroy = true }
+  tags      = { Name = "alb-certificate" }
+}
+
+resource "aws_acm_certificate" "cdn" {
+  provider          = aws.us_east_1
+  domain_name       = "parcel-management.qawitherev.com"
+  validation_method = "DNS"
+
+  lifecycle { create_before_destroy = true }
+  tags      = { Name = "cdn-certificate" }
+}
+
+# ============================================================
+# ALB (public, in public subnets)
+# ============================================================
+
+resource "aws_lb" "main" {
+  name               = "parcel-management-production"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = aws_subnet.public[*].id
+
+  tags = { Name = "parcel-management-production" }
+}
+
+resource "aws_lb_target_group" "backend" {
+  name        = "pm-production-backend"
+  port        = 5163
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.main.id
+  target_type = "ip"
+
+  health_check {
+    path                = "/health"
+    protocol            = "HTTP"
+    matcher             = "200"
+    interval            = 30
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+  }
+}
+
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = "443"
+  protocol          = "HTTPS"
+  certificate_arn   = aws_acm_certificate.alb.arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.backend.arn
+  }
+}
+
+# ============================================================
+# SECURITY GROUPS
+# ============================================================
+
+resource "aws_security_group" "alb" {
+  name        = "parcel-management-production-alb"
+  description = "Allow HTTPS from internet"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "ecs" {
+  name        = "parcel-management-production-ecs"
+  description = "Accept traffic only from ALB"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port       = 5163
+    to_port         = 5163
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# ============================================================
+# ECR (container images)
+# ============================================================
+
+resource "aws_ecr_repository" "backend" {
+  name                 = "parcel-management-production-backend"
+  image_tag_mutability = "MUTABLE"
+  force_delete         = true
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = { Name = "backend-ecr" }
+}
+
+# ============================================================
+# ECS FARGATE (in private subnets)
+# ============================================================
+
+resource "aws_ecs_cluster" "main" {
+  name = "parcel-management-production"
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+
+  tags = { Name = "ecs-cluster" }
+}
+
+resource "aws_ecs_task_definition" "backend" {
+  family                   = "parcel-management-production-backend"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "512"
+  memory                   = "1024"
+  network_mode             = "awsvpc"
+
+  container_definitions = jsonencode([{
+    name  = "backend"
+    image = "${aws_ecr_repository.backend.repository_url}:latest"
+    portMappings = [{
+      containerPort = 5163
+      protocol      = "tcp"
+    }]
+  }])
+
+  tags = { Name = "backend-task-def" }
+}
+
+resource "aws_ecs_service" "backend" {
+  name            = "parcel-management-production-backend"
+  task_definition = aws_ecs_task_definition.backend.arn
+  cluster         = aws_ecs_cluster.main.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = aws_subnet.private[*].id
+    security_groups  = [aws_security_group.ecs.id]
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.backend.arn
+    container_name   = "backend"
+    container_port   = 5163
+  }
+
+  tags = { Name = "backend-service" }
+}
+
+# ============================================================
+# S3 + CLOUDFRONT (frontend hosting)
+# ============================================================
+
+resource "aws_s3_bucket" "frontend" {
+  bucket        = "parcel-management-production-frontend"
+  force_destroy = true
+
+  tags = { Name = "frontend-bucket" }
+}
+
+resource "aws_cloudfront_origin_access_control" "frontend" {
+  name                              = "parcel-management-production-frontend"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+resource "aws_cloudfront_distribution" "frontend" {
+  enabled             = true
+  default_root_object = "index.html"
+  price_class         = "PriceClass_100"
+  aliases             = ["parcel-management.qawitherev.com"]
+
+  origin {
+    domain_name              = aws_s3_bucket.frontend.bucket_regional_domain_name
+    origin_id                = aws_s3_bucket.frontend.id
+    origin_access_control_id = aws_cloudfront_origin_access_control.frontend.id
+  }
+
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD", "OPTIONS"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = aws_s3_bucket.frontend.id
+    viewer_protocol_policy = "redirect-to-https"
+    compress               = true
+
+    forwarded_values {
+      query_string = false
+      cookies { forward = "none" }
+    }
+
+    min_ttl     = 0
+    default_ttl = 3600
+    max_ttl     = 86400
+  }
+
+  custom_error_response {
+    error_code         = 404
+    response_code      = 200
+    response_page_path = "/index.html"
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate.cdn.arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  tags = { Name = "cloudfront-distribution" }
+}
+
+# ============================================================
+# ROUTE53 DNS
+# ============================================================
+
+resource "aws_route53_zone" "root" {
+  name = "qawitherev.com"
+}
+
+resource "aws_route53_record" "api" {
+  zone_id = aws_route53_zone.root.zone_id
+  name    = "api-parcel-management.qawitherev.com"
+  type    = "A"
+
+  alias {
+    name                   = aws_lb.main.dns_name
+    zone_id                = aws_lb.main.zone_id
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_route53_record" "app" {
+  zone_id = aws_route53_zone.root.zone_id
+  name    = "parcel-management.qawitherev.com"
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.frontend.domain_name
+    zone_id                = aws_cloudfront_distribution.frontend.hosted_zone_id
+    evaluate_target_health = false
+  }
+}

--- a/frontend/src/environment/environment.prod.ts
+++ b/frontend/src/environment/environment.prod.ts
@@ -1,4 +1,4 @@
 export const environment = {
-    apiBaseUrl: "https://api.parcel-management.qawitherev.com/api", 
+    apiBaseUrl: "https://api-parcel-management.qawitherev.com/api",
     enabledLogging: false
 }

--- a/frontend/src/environment/environment.staging.ts
+++ b/frontend/src/environment/environment.staging.ts
@@ -1,4 +1,4 @@
 export const environment = {
-    apiBaseUrl: "https://api.staging.parcel-management.qawitherev.com/api",
+    apiBaseUrl: "https://api-staging-parcel-management.qawitherev.com/api",
     enabledLogging: false
 };

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -215,9 +215,9 @@ User's Browser
 ├── https://parcel-management.qawitherev.com
 │   └── Route53 → CloudFront → S3 (static frontend files)
 │       │
-│       └── Angular reads config.json → apiUrl = "https://api.parcel-management.qawitherev.com"
+│       └── Angular reads config.json → apiUrl = "https://api-parcel-management.qawitherev.com"
 │
-└── https://api.parcel-management.qawitherev.com
+└── https://api-parcel-management.qawitherev.com
     └── Route53 → ALB (HTTPS, ACM cert) → ECS Fargate (backend :5163)
 
 ┌──────────────────────────────────────────────────────────────────┐

--- a/terraform/architecture-diagram.html
+++ b/terraform/architecture-diagram.html
@@ -1,0 +1,395 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Parcel Management System — AWS Architecture</title>
+<style>
+  * { margin:0; padding:0; box-sizing:border-box; }
+  body {
+    background: #f0f2f5;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    display: flex; flex-direction: column; align-items: center;
+    padding: 24px;
+  }
+  header { text-align:center; margin-bottom:20px; }
+  header h1 { font-size:1.3rem; color:#232f3e; font-weight:700; }
+  header p  { font-size:0.78rem; color:#666; margin-top:4px; }
+
+  .tabs { display:flex; gap:8px; margin-bottom:16px; }
+  .tabs button {
+    padding:7px 22px; border-radius:6px; border:1.5px solid #d4d8dd;
+    background:#fff; color:#444; cursor:pointer; font-size:0.78rem; font-weight:600;
+    transition: all .15s;
+  }
+  .tabs button.active { background:#232f3e; color:#fff; border-color:#232f3e; }
+
+  .canvas-wrap {
+    background:#fff; border-radius:10px; box-shadow:0 2px 16px rgba(0,0,0,.08);
+    padding:10px; overflow:auto; max-width:100%;
+  }
+  svg { display:block; }
+</style>
+</head>
+<body>
+
+<header>
+  <h1>Parcel Management System — AWS Architecture</h1>
+  <p>ap-southeast-1 (Singapore) &nbsp;·&nbsp; IaC with Terraform &nbsp;·&nbsp; 11 modules &nbsp;·&nbsp; 2 environments</p>
+</header>
+
+<div class="tabs">
+  <button class="active" onclick="switchEnv('production')">Production</button>
+  <button onclick="switchEnv('staging')">Staging</button>
+</div>
+
+<div class="canvas-wrap">
+  <svg id="arch" viewBox="0 0 1450 1000" width="1450" height="1000"
+       style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif;">
+  </svg>
+</div>
+
+<script>
+const ENVS = {
+  production: {
+    vpcCidr:'10.0.0.0/16',
+    pubA:'10.0.1.0/24', pubB:'10.0.2.0/24',
+    privA:'10.0.101.0/24', privB:'10.0.102.0/24',
+    cpu:'512', mem:'1024 MB', desired:'1',
+    appDomain:'parcel-management.qawitherev.com',
+    apiDomain:'api-parcel-management.qawitherev.com',
+    ssmPath:'production',
+    branch:'main',
+    cluster:'parcel-management-production',
+    ecr:'parcel-management-production-backend',
+    bucket:'parcel-management-production-frontend',
+    compute:false,
+  },
+  staging: {
+    vpcCidr:'10.1.0.0/16',
+    pubA:'10.1.1.0/24', pubB:'10.1.2.0/24',
+    privA:'10.1.101.0/24', privB:'10.1.102.0/24',
+    cpu:'256', mem:'512 MB', desired:'1',
+    appDomain:'staging.parcel-management.qawitherev.com',
+    apiDomain:'api-staging-parcel-management.qawitherev.com',
+    ssmPath:'staging',
+    branch:'staging',
+    cluster:'parcel-management-staging',
+    ecr:'parcel-management-staging-backend',
+    bucket:'parcel-management-staging-frontend',
+    compute:false,
+  }
+};
+let E = ENVS.production;
+
+const C = {
+  r53:'#8C4FFF',  cf:'#8C4FFF',   s3:'#569A31',
+  alb:'#7B2CBF',  ecs:'#3B7DD8',  ecr:'#D13212',
+  iam:'#DD344C',  cw:'#FF4F8B',   ssm:'#D13212',
+  awsOrange:'#FF9900',
+  vpc:'#2E7D32',  pub:'#42A5F5',  priv:'#EF5350',
+  gh:'#24292E',
+  text:'#232F3E', gray:'#666',  lgray:'#999',
+  arrow:'#999',
+};
+
+const ns='http://www.w3.org/2000/svg';
+
+function el(tag,attrs){
+  const e=document.createElementNS(ns,tag);
+  for(const k in attrs) e.setAttribute(k,attrs[k]);
+  return e;
+}
+function R(x,y,w,h,rx,fill,stroke,sw,cls){
+  const a={x:x,y:y,width:w,height:h,rx:rx||4,fill:fill||'none',stroke:stroke||'none','stroke-width':sw||1};
+  if(cls) a['class']=cls;
+  return el('rect',a);
+}
+function T(x,y,str,fs,fill,weight,anchor){
+  const t=el('text',{x:x,y:y,'font-size':fs||'0.7rem',fill:fill||C.text,'font-weight':weight||'400'});
+  if(anchor) t.setAttribute('text-anchor',anchor);
+  t.textContent=str;
+  return t;
+}
+function L(x1,y1,x2,y2,stroke,sw,dash){
+  const a={x1:x1,y1:y1,x2:x2,y2:y2,stroke:stroke||C.arrow,'stroke-width':sw||1.3};
+  if(dash) a['stroke-dasharray']=dash;
+  return el('line',a);
+}
+function arrowHead(cx,cy,angle,color){
+  const s=5, a=angle*Math.PI/180;
+  const x1=cx+s*Math.cos(a+2.5), y1=cy+s*Math.sin(a+2.5);
+  const x2=cx+s*Math.cos(a-2.5), y2=cy+s*Math.sin(a-2.5);
+  return el('polygon',{points:`${cx},${cy} ${x1},${y1} ${x2},${y2}`,fill:color||C.arrow});
+}
+function arrowV(x,y1,y2,color){
+  const g=document.createElementNS(ns,'g');
+  g.appendChild(L(x,y1,x,y2,color||C.arrow,1.4));
+  g.appendChild(arrowHead(x,y2,270,color||C.arrow));
+  return g;
+}
+function arrowH(x1,x2,y,color){
+  const g=document.createElementNS(ns,'g');
+  g.appendChild(L(x1,y,x2,y,color||C.arrow,1.4));
+  g.appendChild(arrowHead(x2,y,x2>x1?0:180,color||C.arrow));
+  return g;
+}
+function arrowD(d,color){
+  const g=document.createElementNS(ns,'g');
+  g.appendChild(el('path',{d:d,fill:'none',stroke:color||C.arrow,'stroke-width':1.4}));
+  // get last segment for arrowhead
+  const pts=d.split(/[,\s]+/).filter(Number).map(Number);
+  const ex=pts[pts.length-2], ey=pts[pts.length-1];
+  const px=pts[pts.length-4], py=pts[pts.length-3];
+  const dx=ex-px, dy=ey-py;
+  const ang=Math.atan2(dy,dx)*180/Math.PI;
+  g.appendChild(arrowHead(ex,ey,ang,color||C.arrow));
+  return g;
+}
+
+// ── service card ──
+function card(x,y,w,h,color,title,lines,small){
+  const g=document.createElementNS(ns,'g');
+  const fs=small?0.58:0.62, ts=small?0.62:0.68;
+  g.appendChild(R(x+1,y+1,w,h,5,'rgba(0,0,0,0.04)'));
+  g.appendChild(R(x,y,w,h,5,'#fff',color,1.5));
+  // header bar
+  g.appendChild(R(x,y,w,small?20:22,0,color));
+  // title on colored bar
+  g.appendChild(T(x+10,y+(small?14:15),title,ts,'#fff','700'));
+  // detail lines
+  lines.forEach((l,i)=>{
+    g.appendChild(T(x+10,y+(small?28:30)+(small?11:12)*i,l,fs,C.gray,'400'));
+  });
+  return g;
+}
+
+function draw(){
+  const svg=document.getElementById('arch');
+  svg.innerHTML='';
+
+  // ═══════════ AWS CLOUD ═══════════
+  svg.appendChild(R(8,8,1434,984,14,'rgba(255,153,0,0.018)',C.awsOrange,2.5));
+  // label
+  svg.appendChild(R(28,-6,102,14,0,'#fff'));
+  svg.appendChild(T(44,4,'☁ AWS Cloud',0.82,C.awsOrange,'700'));
+  svg.appendChild(T(1300,22,'Region: ap-southeast-1',0.6,C.lgray,'400'));
+
+  // ═══════════ USERS ═══════════
+  const ux=725;
+  // stick figure
+  svg.appendChild(el('circle',{cx:ux,cy:45,r:11,fill:'none',stroke:C.gray,'stroke-width':1.6}));
+  svg.appendChild(L(ux,56,ux,77,C.gray,1.6));
+  svg.appendChild(L(ux-16,63,ux+16,63,C.gray,1.6));
+  svg.appendChild(L(ux,77,ux-14,92,C.gray,1.6));
+  svg.appendChild(L(ux,77,ux+14,92,C.gray,1.6));
+  svg.appendChild(T(ux,110,'End Users',0.74,C.text,'600','middle'));
+  svg.appendChild(T(ux,126,'Browser · Mobile · API clients',0.6,C.lgray,'400','middle'));
+
+  // ═══════════ ROUTE53 ═══════════
+  const r53={x:550,y:140,w:350,h:52};
+  svg.appendChild(card(r53.x,r53.y,r53.w,r53.h,C.r53,'Amazon Route53',[
+    E.appDomain,
+    'Hosted Zone: qawitherev.com (pre-existing)',
+  ]));
+
+  // user → R53
+  svg.appendChild(arrowV(ux,92,r53.y,C.r53));
+
+  // ═══════════ TRAFFIC SPLIT ═══════════
+  // R53 → CloudFront (left)
+  svg.appendChild(arrowD(`M${r53.x+60},192 C${r53.x+60},212 370,212 370,230`,C.cf));
+  // R53 → VPC/ALB (right)
+  svg.appendChild(arrowD(`M${r53.x+r53.w-60},192 C${r53.x+r53.w-60},240 1080,240 1080,310`,C.alb));
+  // labels
+  svg.appendChild(T(r53.x-10,210,'app.* →',0.58,C.lgray,'400','end'));
+  svg.appendChild(T(r53.x+r53.w+10,210,'← api.*',0.58,C.lgray,'400','start'));
+
+  // ═══════════ FRONTEND PATH ═══════════
+  const cf={x:190,y:234,w:320,h:58};
+  svg.appendChild(card(cf.x,cf.y,cf.w,cf.h,C.cf,'Amazon CloudFront',[
+    'Price Class 200 · TLS 1.2_2021 · OAC (SigV4)',
+    'SPA fallback: 404 → /index.html  ·  Compression: enabled',
+  ]));
+  svg.appendChild(arrowV(cf.x+160,292,326,C.s3));
+
+  const s3box={x:190,y:330,w:320,h:50};
+  svg.appendChild(card(s3box.x,s3box.y,s3box.w,s3box.h,C.s3,'Amazon S3',[
+    E.bucket,
+    'Public access: fully blocked · CloudFront OAC only',
+  ]));
+
+  svg.appendChild(T(s3box.x+160,396,'⬆ Angular SPA static assets',0.58,C.s3,'500','middle'));
+
+  // ═══════════ VPC ═══════════
+  const vpc={x:560,y:312,w:640,h:420};
+  // VPC boundary
+  svg.appendChild(R(vpc.x,vpc.y,vpc.w,vpc.h,12,'rgba(46,125,50,0.025)',C.vpc,2.2));
+  // VPC label
+  svg.appendChild(R(vpc.x+14,vpc.y-14,162,20,0,'#fff'));
+  svg.appendChild(T(vpc.x+24,vpc.y,'VPC  ·  '+E.vpcCidr,0.74,C.vpc,'700'));
+
+  // ─── PUBLIC SUBNETS ───
+  const pub={x:vpc.x+16,y:vpc.y+28,w:vpc.w-32,h:88};
+  svg.appendChild(R(pub.x,pub.y,pub.w,pub.h,7,'rgba(66,165,245,0.04)',C.pub,1.5));
+  svg.appendChild(T(pub.x+14,pub.y+17,'Public Subnets',0.64,C.pub,'600'));
+
+  // ALB inside public subnets
+  const albA=card(pub.x+16,pub.y+32,(pub.w-48)/2,46,C.alb,'AZ: ap-southeast-1a',[
+    E.pubA+'  ·  ALB endpoint',
+  ],true);
+  svg.appendChild(albA);
+  const albB=card(pub.x+pub.w/2+8,pub.y+32,(pub.w-48)/2,46,C.alb,'AZ: ap-southeast-1b',[
+    E.pubB+'  ·  ALB endpoint',
+  ],true);
+  svg.appendChild(albB);
+
+  // ALB detail card (spanning both AZs)
+  svg.appendChild(card(pub.x+60,pub.y+12,520,18,C.alb,'Application Load Balancer — Internet-facing · HTTP:80 + HTTPS:443 · Target: IP :5163',[],true));
+
+  // ─── PRIVATE SUBNETS ───
+  const priv={x:vpc.x+16,y:pub.y+pub.h+16,w:vpc.w-32,h:130};
+  svg.appendChild(R(priv.x,priv.y,priv.w,priv.h,7,'rgba(239,83,80,0.04)',C.priv,1.5));
+  svg.appendChild(T(priv.x+14,priv.y+17,'Private Subnets',0.64,C.priv,'600'));
+
+  // ECS tasks inside private subnets
+  const taskA=card(priv.x+16,priv.y+32,(priv.w-48)/2,88,C.ecs,'AZ: ap-southeast-1a',[
+    E.privA,
+    'ECS Fargate task',
+    'Container: backend :5163',
+    'Health: GET /health → 200',
+  ],true);
+  svg.appendChild(taskA);
+  const taskB=card(priv.x+priv.w/2+8,priv.y+32,(priv.w-48)/2,88,C.ecs,'AZ: ap-southeast-1b',[
+    E.privB,
+    'ECS Fargate task',
+    'Container: backend :5163',
+    'Health: GET /health → 200',
+  ],true);
+  svg.appendChild(taskB);
+
+  // Traffic arrows: ALB → ECS tasks
+  svg.appendChild(arrowD(`M${pub.x+pub.w/4},${pub.y+pub.h} C${pub.x+pub.w/4},${priv.y} ${priv.x+priv.w/4},${priv.y+32} ${priv.x+priv.w/4},${priv.y+32}`,C.alb));
+  svg.appendChild(arrowD(`M${pub.x+3*pub.w/4},${pub.y+pub.h} C${pub.x+3*pub.w/4},${priv.y} ${priv.x+3*priv.w/4},${priv.y+32} ${priv.x+3*priv.w/4},${priv.y+32}`,C.alb));
+
+  // ─── GATEWAYS ───
+  const gwY=priv.y+priv.h+16;
+  // IGW
+  svg.appendChild(card(pub.x+40,gwY,140,30,'#aaa','Internet Gateway',[],true));
+  svg.appendChild(L(pub.x+110,gwY,pub.x+110,pub.y+pub.h,C.arrow,0.7,'3,3'));
+  // NAT GW
+  const natEl=card(pub.x+pub.w-200,gwY,160,30,'#aaa','NAT Gateway + EIP',[],true);
+  natEl.setAttribute('id','nat-gw');
+  svg.appendChild(natEl);
+  svg.appendChild(L(pub.x+pub.w-120,gwY,pub.x+pub.w-120,priv.y+priv.h,C.arrow,0.7,'3,3'));
+
+  // ─── ECS CLUSTER INFO ───
+  const ecsY=gwY+46;
+  svg.appendChild(card(vpc.x+80,ecsY,480,50,C.ecs,'Amazon ECS Cluster (Fargate)',[
+    'Cluster: '+E.cluster+'  ·  CPU: '+E.cpu+'  ·  Memory: '+E.mem+'  ·  Tasks: '+E.desired,
+    'Network mode: awsvpc  ·  Platform: Linux/x86_64  ·  Container Insights: on',
+  ]));
+
+  // ═══════════ SUPPORTING SERVICES (left column) ═══════════
+  const sY=330;
+  // ECR
+  svg.appendChild(card(30,sY,280,68,C.ecr,'Amazon ECR',[
+    'Repository: '+E.ecr,
+    'Tags: IMMUTABLE · Scan on push: enabled',
+    'Lifecycle: expire untagged after 7d, keep 10',
+  ]));
+  // ECR → ECS
+  svg.appendChild(arrowD(`M310,${sY+34} C400,${sY+34} 480,${ecsY+20} ${vpc.x+80},${ecsY+20}`,C.ecr));
+
+  // SSM
+  svg.appendChild(card(30,sY+90,280,68,C.ssm,'SSM Parameter Store',[
+    'Path: /'+E.ssmPath+'/backend/',
+    '5 SecureString + 9 String parameters',
+    'DB · JWT · SendGrid · Redis · Admin passwords',
+  ]));
+  // SSM → ECS
+  svg.appendChild(arrowD(`M310,${sY+124} C400,${sY+124} 480,${ecsY+35} ${vpc.x+80},${ecsY+35}`,C.ssm));
+
+  // IAM
+  svg.appendChild(card(30,sY+180,280,82,C.iam,'AWS IAM',[
+    'Task Execution Role: ECR pull + SSM read',
+    'Task Role: app-level S3, SES, SQS perms',
+    'CI/CD User: ECR + ECS + S3 + CloudFront',
+    'OIDC Role: GitHub Actions → AdminAccess',
+  ]));
+
+  // CloudWatch
+  svg.appendChild(card(30,sY+280,280,58,C.cw,'Amazon CloudWatch',[
+    'Dashboard: '+E.ssmPath,
+    '12 widgets: ALB health · ECS CPU/Mem · CF metrics',
+    'Logs: /ecs/parcel-management-system',
+  ]));
+
+  // ═══════════ ACM CERTIFICATES ═══════════
+  svg.appendChild(card(250,vpc.y+vpc.h+16,340,50,'#7B2CBF','ACM Certificate — ALB (ap-southeast-1)',[
+    'SAN: '+E.appDomain+'  +  '+E.apiDomain+'  ·  DNS-validated via Route53',
+  ],true));
+  svg.appendChild(card(620,vpc.y+vpc.h+16,380,50,'#8C4FFF','ACM Certificate — CloudFront (us-east-1)',[
+    'Domain: '+E.appDomain+'  ·  DNS-validated via Route53',
+  ],true));
+
+  // ═══════════ CI/CD ═══════════
+  const ciY=vpc.y+vpc.h+80;
+  // GitHub Actions
+  svg.appendChild(card(100,ciY,290,66,C.gh,'GitHub Actions',[
+    'Repo: qawitherev/parcel-management-system',
+    'Trigger: push to '+E.branch+'  ·  Environment: '+E.ssmPath,
+    'Docker build + push to ECR (tag = git SHA)',
+  ]));
+  // → OIDC
+  svg.appendChild(arrowH(390,480,ciY+33,C.gray));
+
+  // OIDC Provider
+  svg.appendChild(card(480,ciY,320,66,C.iam,'AWS IAM OIDC Provider',[
+    'Federation: token.actions.githubusercontent.com',
+    'Assume Role: github-actions-'+E.ssmPath,
+    E.ssmPath==='production'
+      ?'OIDC provider resource created here (one per account)'
+      :'Reuses production OIDC provider (only one per account)',
+  ]));
+  // → deploy steps
+  svg.appendChild(arrowH(800,920,ciY+33,C.gray));
+
+  // Deploy steps
+  const ds={x:920,y:ciY,w:320,h:130};
+  svg.appendChild(R(ds.x,ds.y,ds.w,ds.h,6,'#f9f9f9','#ddd',1));
+  svg.appendChild(T(ds.x+ds.w/2,ds.y+18,'CI/CD Deploy Flow',0.64,C.text,'700','middle'));
+  [
+    '1. Docker build & push to ECR (tag = git SHA)',
+    '2. Register new ECS task definition revision',
+    '3. Update ECS service → force new deployment',
+    '4. CloudFront invalidation (if frontend changed)',
+    '5. Health check: curl /health on new task',
+  ].forEach((s,i)=>{
+    svg.appendChild(T(ds.x+14,ds.y+42+i*17,s,0.58,C.gray,'400'));
+  });
+
+  // GitHub → deploy box connector
+  svg.appendChild(arrowD(`M${ds.x-300},${ciY+58} C${ds.x-150},${ciY+120} ${ds.x},${ciY+80} ${ds.x},${ciY+65}`,C.gray));
+
+  // ═══════════ COST-SAVING BADGE ═══════════
+  if(!E.compute){
+    svg.appendChild(R(vpc.x+120,vpc.y+vpc.h-5,440,22,5,'#FFF3E0','#FFB74D',1.2));
+    svg.appendChild(T(vpc.x+340,vpc.y+vpc.h+10,'⚠  enable_compute = false — ALB, NAT Gateway, ECS service NOT deployed (cost-saving mode)',0.58,'#E65100','500','middle'));
+    const nat=svg.querySelector('#nat-gw');
+    if(nat) nat.setAttribute('opacity','0.3');
+  }
+}
+
+function switchEnv(name){
+  E = ENVS[name];
+  document.querySelectorAll('.tabs button').forEach(b=>{
+    b.classList.toggle('active', b.textContent.trim().toLowerCase()===name);
+  });
+  draw();
+}
+
+draw();
+</script>
+</body>
+</html>


### PR DESCRIPTION
Change API endpoints from dot-separated (2-level nested) to hyphen-separated (1-level nested) subdomains to work with Cloudflare Tunnel's certificate limitation (only supports 1 level of subdomain nesting).

- Production: api.parcel-management.qawitherev.com → api-parcel-management.qawitherev.com
- Staging:   api.staging.parcel-management.qawitherev.com → api-staging-parcel-management.qawitherev.com

Updated:
- frontend environment configs (prod + staging)
- CD workflow smoke-test domain computation
- Terraform/brainboard cert SANs and Route53 records
- WSL2 implementation plan: switch SSH from Cloudflare Tunnel to Tailscale, fix username references, add DNS router cache troubleshooting
- Infrastructure docs and architecture diagram